### PR TITLE
End footnote definition with one blank line.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -347,14 +347,15 @@ impl<'a> RawParser<'a> {
             if at_eol {
                 self.off += n;
                 self.state = State::StartBlock;
-                // two empty lines closes lists and footnotes
+                // two empty lines closes lists, one empty line closes a footnote
                 let (n, empty_lines) = self.scan_empty_lines(&self.text[self.off ..]);
                 //println!("{} empty lines (n = {})", empty_lines, n);
                 let mut closed = false;
-                if empty_lines >= 1 {
+                {
                     let mut close_tags: Vec<&mut (Tag<'a>, usize, usize)> = self.stack.iter_mut().skip_while(|tag| {
                         match tag.0 {
-                            Tag::List(_) | Tag::FootnoteDefinition(_) => false,
+                            Tag::List(_) => empty_lines == 0,
+                            Tag::FootnoteDefinition(_) => false,
                             _ => true,
                         }
                     }).collect();


### PR DESCRIPTION
According to the linked issue, a footnote definition should end with a
blank line. This is similar to the rule for lists, which end with two
blank lines. The code previously required two blank lines in both
cases, this patch changes it to just one for footnote definitions.

Fixes issue 20.
