### PR TITLE
Apply emphasis/strong when split across multiple lines in a container.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1026,7 +1026,11 @@ impl<'a> RawParser<'a> {
         while i < limit {
             let c2 = data.as_bytes()[i];
             if c2 == b'\n' && !is_escaped(data, i) {
-                let space = 0;  // TODO: scan containers
+                let (_, complete, space) = self.scan_containers(&self.text[i..]);
+                if !complete {
+                    i += 1;
+                    continue;
+                }
                 if self.is_inline_block_end(&self.text[i + 1 .. limit], space) {
                     return None
                 } else {


### PR DESCRIPTION
```
> *two
> words*
```
now produces:
```
<blockquote>
<p><em>two
words</em></p>
</blockquote>
```
instead of:
```
<blockquote>
<p>*two
words*</p>
</blockquote>
```