### PR TITLE
Split out binary and lib build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark"
-version = "0.0.10"
+version = "0.0.11"
 authors = [ "Raph Levien <raph@google.com>" ]
 license = "MIT"
 description = "A pull parser for CommonMark"
@@ -12,11 +12,13 @@ build = "build.rs"
 [[bin]]
 name = "pulldown-cmark"
 doc = false
+required-features = ["binary"]
 
 [dependencies]
-getopts = "0.2"
 bitflags = "0.8"
+getopts = { version = "0.2", optional = true }
 
 [features]
 default = []
 gen-tests = []
+binary = ["getopts"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ strings are available when they're needed. Thus, when rendering text to
 HTML, most text is copied just once, from the source document to the
 HTML buffer.
 
+## Building the pulldown-cmark binary
+
+By default it is not built. To do so:
+
+```bash
+> cargo build --features=binary
+```
+
 ## Authors
 
 The main author is Raph Levien.

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@
 
 //! Command line tool to exercise pulldown-cmark.
 
+#![cfg(feature = "binary")]
+
 extern crate getopts;
 
 extern crate pulldown_cmark;


### PR DESCRIPTION
Otherwise we can't use it in rust because of the `getopts` duplicate.