### PR TITLE
Tab characters may appear in expected too

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
 
         let our_html = render_html(&test.input.replace("→", "\t").replace("\n", "\r\n"), opts);
 
-        if our_html == test.expected {
+        if our_html == test.expected.replace("→", "\t") {
             print!(".");
         } else {
             if tests_failed == 0 {


### PR DESCRIPTION
Refs #57. This doesn't actually bump up the spec success count yet since the tests it's implicated in are failing for other reasons.