### PR TITLE
Make pulldown-cmark library rustc build system compliant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark"
-version = "0.0.11"
+version = "0.0.12"
 authors = [ "Raph Levien <raph@google.com>" ]
 license = "MIT"
 description = "A pull parser for CommonMark"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,11 @@
 
 //! Pull parser for commonmark.
 
+// When compiled for the rustc compiler itself we want to make sure that this is
+// an unstable crate.
+#![cfg_attr(rustbuild, feature(staged_api))]
+#![cfg_attr(rustbuild, unstable(feature = "rustdoc", issue = "27812"))]
+
 pub mod html;
 
 #[macro_use]


### PR DESCRIPTION
Sorry to bother you once again... External crates used by rustc needs this as well. In hope it'll be the last rustc-bound PR.