### PR TITLE
Add rustc_private feature as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark"
-version = "0.0.13"
+version = "0.0.14"
 authors = [ "Raph Levien <raph@google.com>" ]
 license = "MIT"
 description = "A pull parser for CommonMark"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 
 // When compiled for the rustc compiler itself we want to make sure that this is
 // an unstable crate.
-#![cfg_attr(rustbuild, feature(staged_api))]
+#![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
 #![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
 
 pub mod html;


### PR DESCRIPTION
And since we have a sub-dependency (bitflags) which needs to be unstable, we need to activate the feature in here as well. (Someday, it'll finally work!)