### PR TITLE
Update spec.txt to jgm/CommonMark tagged 0.27

### DIFF
--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -11437,7 +11437,49 @@ bar>)</p>
 
     #[test]
     fn spec_test_465() {
+        let original = r##"[link]((foo)and(bar))
+"##;
+        let expected = r##"<p><a href="(foo)and(bar)">link</a></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_466() {
         let original = r##"[link](foo(and(bar)))
+"##;
+        let expected = r##"<p>[link](foo(and(bar)))</p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_467() {
+        let original = r##"[link](foo(and\(bar\)))
 "##;
         let expected = r##"<p><a href="foo(and(bar))">link</a></p>
 "##;
@@ -11457,49 +11499,28 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_466() {
-        let original = r##"[link](foo\(and\(bar\))
-"##;
-        let expected = r##"<p><a href="foo(and(bar)">link</a></p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
-    fn spec_test_467() {
-        let original = r##"[link](<foo(and(bar)>)
-"##;
-        let expected = r##"<p><a href="foo(and(bar)">link</a></p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
     fn spec_test_468() {
+        let original = r##"[link](<foo(and(bar))>)
+"##;
+        let expected = r##"<p><a href="foo(and(bar))">link</a></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_469() {
         let original = r##"[link](foo\)\:)
 "##;
         let expected = r##"<p><a href="foo):">link</a></p>
@@ -11520,7 +11541,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_469() {
+    fn spec_test_470() {
         let original = r##"[link](#fragment)
 
 [link](http://example.com#fragment)
@@ -11547,7 +11568,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_470() {
+    fn spec_test_471() {
         let original = r##"[link](foo\bar)
 "##;
         let expected = r##"<p><a href="foo%5Cbar">link</a></p>
@@ -11568,7 +11589,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_471() {
+    fn spec_test_472() {
         let original = r##"[link](foo%20b&auml;)
 "##;
         let expected = r##"<p><a href="foo%20b%C3%A4">link</a></p>
@@ -11589,7 +11610,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_472() {
+    fn spec_test_473() {
         let original = r##"[link]("title")
 "##;
         let expected = r##"<p><a href="%22title%22">link</a></p>
@@ -11610,7 +11631,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_473() {
+    fn spec_test_474() {
         let original = r##"[link](/url "title")
 [link](/url 'title')
 [link](/url (title))
@@ -11635,7 +11656,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_474() {
+    fn spec_test_475() {
         let original = r##"[link](/url "title \"&quot;")
 "##;
         let expected = r##"<p><a href="/url" title="title &quot;&quot;">link</a></p>
@@ -11656,7 +11677,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_475() {
+    fn spec_test_476() {
         let original = r##"[link](/url "title")
 "##;
         let expected = r##"<p><a href="/url%C2%A0%22title%22">link</a></p>
@@ -11677,7 +11698,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_476() {
+    fn spec_test_477() {
         let original = r##"[link](/url "title "and" title")
 "##;
         let expected = r##"<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>
@@ -11698,7 +11719,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_477() {
+    fn spec_test_478() {
         let original = r##"[link](/url 'title "and" title')
 "##;
         let expected = r##"<p><a href="/url" title="title &quot;and&quot; title">link</a></p>
@@ -11719,7 +11740,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_478() {
+    fn spec_test_479() {
         let original = r##"[link](   /uri
   "title"  )
 "##;
@@ -11741,7 +11762,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_479() {
+    fn spec_test_480() {
         let original = r##"[link] (/uri)
 "##;
         let expected = r##"<p>[link] (/uri)</p>
@@ -11762,7 +11783,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_480() {
+    fn spec_test_481() {
         let original = r##"[link [foo [bar]]](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
@@ -11783,7 +11804,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_481() {
+    fn spec_test_482() {
         let original = r##"[link] bar](/uri)
 "##;
         let expected = r##"<p>[link] bar](/uri)</p>
@@ -11804,7 +11825,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_482() {
+    fn spec_test_483() {
         let original = r##"[link [bar](/uri)
 "##;
         let expected = r##"<p>[link <a href="/uri">bar</a></p>
@@ -11825,7 +11846,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_483() {
+    fn spec_test_484() {
         let original = r##"[link \[bar](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link [bar</a></p>
@@ -11846,7 +11867,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_484() {
+    fn spec_test_485() {
         let original = r##"[link *foo **bar** `#`*](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
@@ -11867,7 +11888,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_485() {
+    fn spec_test_486() {
         let original = r##"[![moon](moon.jpg)](/uri)
 "##;
         let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
@@ -11888,7 +11909,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_486() {
+    fn spec_test_487() {
         let original = r##"[foo [bar](/uri)](/uri)
 "##;
         let expected = r##"<p>[foo <a href="/uri">bar</a>](/uri)</p>
@@ -11909,7 +11930,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_487() {
+    fn spec_test_488() {
         let original = r##"[foo *[bar [baz](/uri)](/uri)*](/uri)
 "##;
         let expected = r##"<p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
@@ -11930,7 +11951,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_488() {
+    fn spec_test_489() {
         let original = r##"![[[foo](uri1)](uri2)](uri3)
 "##;
         let expected = r##"<p><img src="uri3" alt="[foo](uri2)" /></p>
@@ -11951,7 +11972,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_489() {
+    fn spec_test_490() {
         let original = r##"*[foo*](/uri)
 "##;
         let expected = r##"<p>*<a href="/uri">foo*</a></p>
@@ -11972,7 +11993,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_490() {
+    fn spec_test_491() {
         let original = r##"[foo *bar](baz*)
 "##;
         let expected = r##"<p><a href="baz*">foo *bar</a></p>
@@ -11993,7 +12014,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_491() {
+    fn spec_test_492() {
         let original = r##"*foo [bar* baz]
 "##;
         let expected = r##"<p><em>foo [bar</em> baz]</p>
@@ -12014,7 +12035,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_492() {
+    fn spec_test_493() {
         let original = r##"[foo <bar attr="](baz)">
 "##;
         let expected = r##"<p>[foo <bar attr="](baz)"></p>
@@ -12035,7 +12056,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_493() {
+    fn spec_test_494() {
         let original = r##"[foo`](/uri)`
 "##;
         let expected = r##"<p>[foo<code>](/uri)</code></p>
@@ -12056,7 +12077,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_494() {
+    fn spec_test_495() {
         let original = r##"[foo<http://example.com/?search=](uri)>
 "##;
         let expected = r##"<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
@@ -12077,7 +12098,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_495() {
+    fn spec_test_496() {
         let original = r##"[foo][bar]
 
 [bar]: /url "title"
@@ -12100,7 +12121,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_496() {
+    fn spec_test_497() {
         let original = r##"[link [foo [bar]]][ref]
 
 [ref]: /uri
@@ -12123,7 +12144,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_497() {
+    fn spec_test_498() {
         let original = r##"[link \[bar][ref]
 
 [ref]: /uri
@@ -12146,7 +12167,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_498() {
+    fn spec_test_499() {
         let original = r##"[link *foo **bar** `#`*][ref]
 
 [ref]: /uri
@@ -12169,7 +12190,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_499() {
+    fn spec_test_500() {
         let original = r##"[![moon](moon.jpg)][ref]
 
 [ref]: /uri
@@ -12192,7 +12213,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_500() {
+    fn spec_test_501() {
         let original = r##"[foo [bar](/uri)][ref]
 
 [ref]: /uri
@@ -12215,7 +12236,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_501() {
+    fn spec_test_502() {
         let original = r##"[foo *bar [baz][ref]*][ref]
 
 [ref]: /uri
@@ -12238,7 +12259,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_502() {
+    fn spec_test_503() {
         let original = r##"*[foo*][ref]
 
 [ref]: /uri
@@ -12261,7 +12282,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_503() {
+    fn spec_test_504() {
         let original = r##"[foo *bar][ref]
 
 [ref]: /uri
@@ -12284,7 +12305,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_504() {
+    fn spec_test_505() {
         let original = r##"[foo <bar attr="][ref]">
 
 [ref]: /uri
@@ -12307,7 +12328,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_505() {
+    fn spec_test_506() {
         let original = r##"[foo`][ref]`
 
 [ref]: /uri
@@ -12330,7 +12351,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_506() {
+    fn spec_test_507() {
         let original = r##"[foo<http://example.com/?search=][ref]>
 
 [ref]: /uri
@@ -12353,7 +12374,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_507() {
+    fn spec_test_508() {
         let original = r##"[foo][BaR]
 
 [bar]: /url "title"
@@ -12376,7 +12397,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_508() {
+    fn spec_test_509() {
         let original = r##"[Толпой][Толпой] is a Russian word.
 
 [ТОЛПОЙ]: /url
@@ -12399,7 +12420,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_509() {
+    fn spec_test_510() {
         let original = r##"[Foo
   bar]: /url
 
@@ -12423,7 +12444,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_510() {
+    fn spec_test_511() {
         let original = r##"[foo] [bar]
 
 [bar]: /url "title"
@@ -12446,7 +12467,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_511() {
+    fn spec_test_512() {
         let original = r##"[foo]
 [bar]
 
@@ -12471,7 +12492,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_512() {
+    fn spec_test_513() {
         let original = r##"[foo]: /url1
 
 [foo]: /url2
@@ -12496,7 +12517,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_513() {
+    fn spec_test_514() {
         let original = r##"[bar][foo\!]
 
 [foo!]: /url
@@ -12519,7 +12540,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_514() {
+    fn spec_test_515() {
         let original = r##"[foo][ref[]
 
 [ref[]: /uri
@@ -12543,7 +12564,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_515() {
+    fn spec_test_516() {
         let original = r##"[foo][ref[bar]]
 
 [ref[bar]]: /uri
@@ -12567,7 +12588,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_516() {
+    fn spec_test_517() {
         let original = r##"[[[foo]]]
 
 [[[foo]]]: /url
@@ -12591,7 +12612,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_517() {
+    fn spec_test_518() {
         let original = r##"[foo][ref\[]
 
 [ref\[]: /uri
@@ -12614,7 +12635,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_518() {
+    fn spec_test_519() {
         let original = r##"[bar\\]: /uri
 
 [bar\\]
@@ -12637,7 +12658,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_519() {
+    fn spec_test_520() {
         let original = r##"[]
 
 []: /uri
@@ -12661,7 +12682,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_520() {
+    fn spec_test_521() {
         let original = r##"[
  ]
 
@@ -12689,7 +12710,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_521() {
+    fn spec_test_522() {
         let original = r##"[foo][]
 
 [foo]: /url "title"
@@ -12712,7 +12733,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_522() {
+    fn spec_test_523() {
         let original = r##"[*foo* bar][]
 
 [*foo* bar]: /url "title"
@@ -12735,7 +12756,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_523() {
+    fn spec_test_524() {
         let original = r##"[Foo][]
 
 [foo]: /url "title"
@@ -12758,7 +12779,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_524() {
+    fn spec_test_525() {
         let original = r##"[foo] 
 []
 
@@ -12783,7 +12804,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_525() {
+    fn spec_test_526() {
         let original = r##"[foo]
 
 [foo]: /url "title"
@@ -12806,7 +12827,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_526() {
+    fn spec_test_527() {
         let original = r##"[*foo* bar]
 
 [*foo* bar]: /url "title"
@@ -12829,7 +12850,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_527() {
+    fn spec_test_528() {
         let original = r##"[[*foo* bar]]
 
 [*foo* bar]: /url "title"
@@ -12852,7 +12873,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_528() {
+    fn spec_test_529() {
         let original = r##"[[bar [foo]
 
 [foo]: /url
@@ -12875,7 +12896,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_529() {
+    fn spec_test_530() {
         let original = r##"[Foo]
 
 [foo]: /url "title"
@@ -12898,7 +12919,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_530() {
+    fn spec_test_531() {
         let original = r##"[foo] bar
 
 [foo]: /url
@@ -12921,7 +12942,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_531() {
+    fn spec_test_532() {
         let original = r##"\[foo]
 
 [foo]: /url "title"
@@ -12944,7 +12965,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_532() {
+    fn spec_test_533() {
         let original = r##"[foo*]: /url
 
 *[foo*]
@@ -12967,7 +12988,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_533() {
+    fn spec_test_534() {
         let original = r##"[foo][bar]
 
 [foo]: /url1
@@ -12991,7 +13012,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_534() {
+    fn spec_test_535() {
         let original = r##"[foo][]
 
 [foo]: /url1
@@ -13014,7 +13035,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_535() {
+    fn spec_test_536() {
         let original = r##"[foo]()
 
 [foo]: /url1
@@ -13037,7 +13058,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_536() {
+    fn spec_test_537() {
         let original = r##"[foo](not a link)
 
 [foo]: /url1
@@ -13060,7 +13081,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_537() {
+    fn spec_test_538() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url
@@ -13083,7 +13104,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_538() {
+    fn spec_test_539() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url1
@@ -13107,7 +13128,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_539() {
+    fn spec_test_540() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url1
@@ -13131,7 +13152,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_540() {
+    fn spec_test_541() {
         let original = r##"![foo](/url "title")
 "##;
         let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
@@ -13152,7 +13173,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_541() {
+    fn spec_test_542() {
         let original = r##"![foo *bar*]
 
 [foo *bar*]: train.jpg "train & tracks"
@@ -13175,7 +13196,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_542() {
+    fn spec_test_543() {
         let original = r##"![foo ![bar](/url)](/url2)
 "##;
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
@@ -13196,7 +13217,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_543() {
+    fn spec_test_544() {
         let original = r##"![foo [bar](/url)](/url2)
 "##;
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
@@ -13217,7 +13238,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_544() {
+    fn spec_test_545() {
         let original = r##"![foo *bar*][]
 
 [foo *bar*]: train.jpg "train & tracks"
@@ -13240,7 +13261,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_545() {
+    fn spec_test_546() {
         let original = r##"![foo *bar*][foobar]
 
 [FOOBAR]: train.jpg "train & tracks"
@@ -13263,7 +13284,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_546() {
+    fn spec_test_547() {
         let original = r##"![foo](train.jpg)
 "##;
         let expected = r##"<p><img src="train.jpg" alt="foo" /></p>
@@ -13284,7 +13305,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_547() {
+    fn spec_test_548() {
         let original = r##"My ![foo bar](/path/to/train.jpg  "title"   )
 "##;
         let expected = r##"<p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
@@ -13305,7 +13326,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_548() {
+    fn spec_test_549() {
         let original = r##"![foo](<url>)
 "##;
         let expected = r##"<p><img src="url" alt="foo" /></p>
@@ -13326,7 +13347,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_549() {
+    fn spec_test_550() {
         let original = r##"![](/url)
 "##;
         let expected = r##"<p><img src="/url" alt="" /></p>
@@ -13347,7 +13368,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_550() {
+    fn spec_test_551() {
         let original = r##"![foo][bar]
 
 [bar]: /url
@@ -13370,7 +13391,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_551() {
+    fn spec_test_552() {
         let original = r##"![foo][bar]
 
 [BAR]: /url
@@ -13393,7 +13414,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_552() {
+    fn spec_test_553() {
         let original = r##"![foo][]
 
 [foo]: /url "title"
@@ -13416,7 +13437,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_553() {
+    fn spec_test_554() {
         let original = r##"![*foo* bar][]
 
 [*foo* bar]: /url "title"
@@ -13439,7 +13460,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_554() {
+    fn spec_test_555() {
         let original = r##"![Foo][]
 
 [foo]: /url "title"
@@ -13462,7 +13483,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_555() {
+    fn spec_test_556() {
         let original = r##"![foo] 
 []
 
@@ -13487,7 +13508,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_556() {
+    fn spec_test_557() {
         let original = r##"![foo]
 
 [foo]: /url "title"
@@ -13510,7 +13531,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_557() {
+    fn spec_test_558() {
         let original = r##"![*foo* bar]
 
 [*foo* bar]: /url "title"
@@ -13533,7 +13554,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_558() {
+    fn spec_test_559() {
         let original = r##"![[foo]]
 
 [[foo]]: /url "title"
@@ -13557,7 +13578,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_559() {
+    fn spec_test_560() {
         let original = r##"![Foo]
 
 [foo]: /url "title"
@@ -13580,7 +13601,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_560() {
+    fn spec_test_561() {
         let original = r##"\!\[foo]
 
 [foo]: /url "title"
@@ -13603,7 +13624,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_561() {
+    fn spec_test_562() {
         let original = r##"\![foo]
 
 [foo]: /url "title"
@@ -13626,7 +13647,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_562() {
+    fn spec_test_563() {
         let original = r##"<http://foo.bar.baz>
 "##;
         let expected = r##"<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
@@ -13647,7 +13668,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_563() {
+    fn spec_test_564() {
         let original = r##"<http://foo.bar.baz/test?q=hello&id=22&boolean>
 "##;
         let expected = r##"<p><a href="http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
@@ -13668,7 +13689,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_564() {
+    fn spec_test_565() {
         let original = r##"<irc://foo.bar:2233/baz>
 "##;
         let expected = r##"<p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
@@ -13689,7 +13710,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_565() {
+    fn spec_test_566() {
         let original = r##"<MAILTO:FOO@BAR.BAZ>
 "##;
         let expected = r##"<p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
@@ -13710,7 +13731,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_566() {
+    fn spec_test_567() {
         let original = r##"<a+b+c:d>
 "##;
         let expected = r##"<p><a href="a+b+c:d">a+b+c:d</a></p>
@@ -13731,7 +13752,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_567() {
+    fn spec_test_568() {
         let original = r##"<made-up-scheme://foo,bar>
 "##;
         let expected = r##"<p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
@@ -13752,7 +13773,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_568() {
+    fn spec_test_569() {
         let original = r##"<http://../>
 "##;
         let expected = r##"<p><a href="http://../">http://../</a></p>
@@ -13773,7 +13794,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_569() {
+    fn spec_test_570() {
         let original = r##"<localhost:5001/foo>
 "##;
         let expected = r##"<p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
@@ -13794,7 +13815,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_570() {
+    fn spec_test_571() {
         let original = r##"<http://foo.bar/baz bim>
 "##;
         let expected = r##"<p>&lt;http://foo.bar/baz bim&gt;</p>
@@ -13815,7 +13836,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_571() {
+    fn spec_test_572() {
         let original = r##"<http://example.com/\[\>
 "##;
         let expected = r##"<p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
@@ -13836,7 +13857,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_572() {
+    fn spec_test_573() {
         let original = r##"<foo@bar.example.com>
 "##;
         let expected = r##"<p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
@@ -13857,7 +13878,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_573() {
+    fn spec_test_574() {
         let original = r##"<foo+special@Bar.baz-bar0.com>
 "##;
         let expected = r##"<p><a href="mailto:foo+special@Bar.baz-bar0.com">foo+special@Bar.baz-bar0.com</a></p>
@@ -13878,7 +13899,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_574() {
+    fn spec_test_575() {
         let original = r##"<foo\+@bar.example.com>
 "##;
         let expected = r##"<p>&lt;foo+@bar.example.com&gt;</p>
@@ -13899,7 +13920,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_575() {
+    fn spec_test_576() {
         let original = r##"<>
 "##;
         let expected = r##"<p>&lt;&gt;</p>
@@ -13920,7 +13941,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_576() {
+    fn spec_test_577() {
         let original = r##"< http://foo.bar >
 "##;
         let expected = r##"<p>&lt; http://foo.bar &gt;</p>
@@ -13941,7 +13962,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_577() {
+    fn spec_test_578() {
         let original = r##"<m:abc>
 "##;
         let expected = r##"<p>&lt;m:abc&gt;</p>
@@ -13962,7 +13983,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_578() {
+    fn spec_test_579() {
         let original = r##"<foo.bar.baz>
 "##;
         let expected = r##"<p>&lt;foo.bar.baz&gt;</p>
@@ -13983,7 +14004,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_579() {
+    fn spec_test_580() {
         let original = r##"http://example.com
 "##;
         let expected = r##"<p>http://example.com</p>
@@ -14004,7 +14025,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_580() {
+    fn spec_test_581() {
         let original = r##"foo@bar.example.com
 "##;
         let expected = r##"<p>foo@bar.example.com</p>
@@ -14025,7 +14046,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_581() {
+    fn spec_test_582() {
         let original = r##"<a><bab><c2c>
 "##;
         let expected = r##"<p><a><bab><c2c></p>
@@ -14046,7 +14067,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_582() {
+    fn spec_test_583() {
         let original = r##"<a/><b2/>
 "##;
         let expected = r##"<p><a/><b2/></p>
@@ -14067,7 +14088,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_583() {
+    fn spec_test_584() {
         let original = r##"<a  /><b2
 data="foo" >
 "##;
@@ -14090,7 +14111,7 @@ data="foo" ></p>
     }
 
     #[test]
-    fn spec_test_584() {
+    fn spec_test_585() {
         let original = r##"<a foo="bar" bam = 'baz <em>"</em>'
 _boolean zoop:33=zoop:33 />
 "##;
@@ -14113,7 +14134,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_585() {
+    fn spec_test_586() {
         let original = r##"Foo <responsive-image src="foo.jpg" />
 "##;
         let expected = r##"<p>Foo <responsive-image src="foo.jpg" /></p>
@@ -14134,7 +14155,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_586() {
+    fn spec_test_587() {
         let original = r##"<33> <__>
 "##;
         let expected = r##"<p>&lt;33&gt; &lt;__&gt;</p>
@@ -14155,7 +14176,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_587() {
+    fn spec_test_588() {
         let original = r##"<a h*#ref="hi">
 "##;
         let expected = r##"<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>
@@ -14176,7 +14197,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_588() {
+    fn spec_test_589() {
         let original = r##"<a href="hi'> <a href=hi'>
 "##;
         let expected = r##"<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>
@@ -14197,7 +14218,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_589() {
+    fn spec_test_590() {
         let original = r##"< a><
 foo><bar/ >
 "##;
@@ -14220,7 +14241,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_590() {
+    fn spec_test_591() {
         let original = r##"<a href='bar'title=title>
 "##;
         let expected = r##"<p>&lt;a href='bar'title=title&gt;</p>
@@ -14241,7 +14262,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_591() {
+    fn spec_test_592() {
         let original = r##"</a></foo >
 "##;
         let expected = r##"<p></a></foo ></p>
@@ -14262,7 +14283,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_592() {
+    fn spec_test_593() {
         let original = r##"</a href="foo">
 "##;
         let expected = r##"<p>&lt;/a href=&quot;foo&quot;&gt;</p>
@@ -14283,7 +14304,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_593() {
+    fn spec_test_594() {
         let original = r##"foo <!-- this is a
 comment - with hyphen -->
 "##;
@@ -14306,7 +14327,7 @@ comment - with hyphen --></p>
     }
 
     #[test]
-    fn spec_test_594() {
+    fn spec_test_595() {
         let original = r##"foo <!-- not a comment -- two hyphens -->
 "##;
         let expected = r##"<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
@@ -14327,7 +14348,7 @@ comment - with hyphen --></p>
     }
 
     #[test]
-    fn spec_test_595() {
+    fn spec_test_596() {
         let original = r##"foo <!--> foo -->
 
 foo <!-- foo--->
@@ -14351,7 +14372,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_596() {
+    fn spec_test_597() {
         let original = r##"foo <?php echo $a; ?>
 "##;
         let expected = r##"<p>foo <?php echo $a; ?></p>
@@ -14372,7 +14393,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_597() {
+    fn spec_test_598() {
         let original = r##"foo <!ELEMENT br EMPTY>
 "##;
         let expected = r##"<p>foo <!ELEMENT br EMPTY></p>
@@ -14393,7 +14414,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_598() {
+    fn spec_test_599() {
         let original = r##"foo <![CDATA[>&<]]>
 "##;
         let expected = r##"<p>foo <![CDATA[>&<]]></p>
@@ -14414,7 +14435,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_599() {
+    fn spec_test_600() {
         let original = r##"foo <a href="&ouml;">
 "##;
         let expected = r##"<p>foo <a href="&ouml;"></p>
@@ -14435,7 +14456,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_600() {
+    fn spec_test_601() {
         let original = r##"foo <a href="\*">
 "##;
         let expected = r##"<p>foo <a href="\*"></p>
@@ -14456,7 +14477,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_601() {
+    fn spec_test_602() {
         let original = r##"<a href="\"">
 "##;
         let expected = r##"<p>&lt;a href=&quot;&quot;&quot;&gt;</p>
@@ -14477,31 +14498,8 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_602() {
-        let original = r##"foo  
-baz
-"##;
-        let expected = r##"<p>foo<br />
-baz</p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
     fn spec_test_603() {
-        let original = r##"foo\
+        let original = r##"foo  
 baz
 "##;
         let expected = r##"<p>foo<br />
@@ -14524,7 +14522,7 @@ baz</p>
 
     #[test]
     fn spec_test_604() {
-        let original = r##"foo       
+        let original = r##"foo\
 baz
 "##;
         let expected = r##"<p>foo<br />
@@ -14547,11 +14545,11 @@ baz</p>
 
     #[test]
     fn spec_test_605() {
-        let original = r##"foo  
-     bar
+        let original = r##"foo       
+baz
 "##;
         let expected = r##"<p>foo<br />
-bar</p>
+baz</p>
 "##;
 
         use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
@@ -14570,7 +14568,7 @@ bar</p>
 
     #[test]
     fn spec_test_606() {
-        let original = r##"foo\
+        let original = r##"foo  
      bar
 "##;
         let expected = r##"<p>foo<br />
@@ -14593,6 +14591,29 @@ bar</p>
 
     #[test]
     fn spec_test_607() {
+        let original = r##"foo\
+     bar
+"##;
+        let expected = r##"<p>foo<br />
+bar</p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_608() {
         let original = r##"*foo  
 bar*
 "##;
@@ -14615,7 +14636,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_608() {
+    fn spec_test_609() {
         let original = r##"*foo\
 bar*
 "##;
@@ -14638,7 +14659,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_609() {
+    fn spec_test_610() {
         let original = r##"`code  
 span`
 "##;
@@ -14660,7 +14681,7 @@ span`
     }
 
     #[test]
-    fn spec_test_610() {
+    fn spec_test_611() {
         let original = r##"`code\
 span`
 "##;
@@ -14682,7 +14703,7 @@ span`
     }
 
     #[test]
-    fn spec_test_611() {
+    fn spec_test_612() {
         let original = r##"<a href="foo  
 bar">
 "##;
@@ -14705,7 +14726,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_612() {
+    fn spec_test_613() {
         let original = r##"<a href="foo\
 bar">
 "##;
@@ -14728,7 +14749,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_613() {
+    fn spec_test_614() {
         let original = r##"foo\
 "##;
         let expected = r##"<p>foo\</p>
@@ -14749,7 +14770,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_614() {
+    fn spec_test_615() {
         let original = r##"foo  
 "##;
         let expected = r##"<p>foo</p>
@@ -14770,7 +14791,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_615() {
+    fn spec_test_616() {
         let original = r##"### foo\
 "##;
         let expected = r##"<h3>foo\</h3>
@@ -14791,7 +14812,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_616() {
+    fn spec_test_617() {
         let original = r##"### foo  
 "##;
         let expected = r##"<h3>foo</h3>
@@ -14812,7 +14833,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_617() {
+    fn spec_test_618() {
         let original = r##"foo
 baz
 "##;
@@ -14835,7 +14856,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_618() {
+    fn spec_test_619() {
         let original = r##"foo 
  baz
 "##;
@@ -14858,7 +14879,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_619() {
+    fn spec_test_620() {
         let original = r##"hello $.;'there
 "##;
         let expected = r##"<p>hello $.;'there</p>
@@ -14879,7 +14900,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_620() {
+    fn spec_test_621() {
         let original = r##"Foo χρῆν
 "##;
         let expected = r##"<p>Foo χρῆν</p>
@@ -14900,7 +14921,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_621() {
+    fn spec_test_622() {
         let original = r##"Multiple     spaces
 "##;
         let expected = r##"<p>Multiple     spaces</p>

--- a/third_party/CommonMark/spec.txt
+++ b/third_party/CommonMark/spec.txt
@@ -7148,7 +7148,8 @@ A [link destination](@) consists of either
 - a nonempty sequence of characters that does not include
   ASCII space or control characters, and includes parentheses
   only if (a) they are backslash-escaped or (b) they are part of
-  a balanced pair of unescaped parentheses.
+  a balanced pair of unescaped parentheses that is not itself
+  inside a balanced pair of unescaped parentheses.
 
 A [link title](@)  consists of either
 
@@ -7254,29 +7255,35 @@ Parentheses inside the link destination may be escaped:
 <p><a href="(foo)">link</a></p>
 ````````````````````````````````
 
-Any number parentheses are allowed without escaping, as long as they are
-balanced:
+One level of balanced parentheses is allowed without escaping:
+
+```````````````````````````````` example
+[link]((foo)and(bar))
+.
+<p><a href="(foo)and(bar)">link</a></p>
+````````````````````````````````
+
+However, if you have parentheses within parentheses, you need to escape
+or use the `<...>` form:
 
 ```````````````````````````````` example
 [link](foo(and(bar)))
 .
+<p>[link](foo(and(bar)))</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link](foo(and\(bar\)))
+.
 <p><a href="foo(and(bar))">link</a></p>
 ````````````````````````````````
 
-However, if you have unbalanced parentheses, you need to escape or use the
-`<...>` form:
 
 ```````````````````````````````` example
-[link](foo\(and\(bar\))
+[link](<foo(and(bar))>)
 .
-<p><a href="foo(and(bar)">link</a></p>
-````````````````````````````````
-
-
-```````````````````````````````` example
-[link](<foo(and(bar)>)
-.
-<p><a href="foo(and(bar)">link</a></p>
+<p><a href="foo(and(bar))">link</a></p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
I noticed there are 622 Examples on the [CommonMark 0.27 website](http://spec.commonmark.org/0.27) but only 621 in the test results for pulldown-cmark.

The spec.txt in this repo is not quite the same as the one published at the CommonMark site and jgm/CommonMark's 0.27 tag.  It's labeled 0.27 at the top, but one part has some changes.

There is one test case missing related to parentheses, and some parentheses rules have changed.

Is this just inadvertent error or something intentional?  Submitting this with a PR so you can see the changes easily.