### PR TITLE
updated bitflags 0.8 -> 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ required-features = ["getopts"]
 doc = false
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "0.9"
 getopts = { version = "0.2", optional = true }
 
 [features]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -126,10 +126,10 @@ pub enum Alignment {
 }
 
 bitflags! {
-    pub flags Options: u32 {
-        const OPTION_FIRST_PASS = 1 << 0,
-        const OPTION_ENABLE_TABLES = 1 << 1,
-        const OPTION_ENABLE_FOOTNOTES = 1 << 2,
+    pub struct Options: u32 {
+        const OPTION_FIRST_PASS = 1 << 0;
+        const OPTION_ENABLE_TABLES = 1 << 1;
+        const OPTION_ENABLE_FOOTNOTES = 1 << 2;
     }
 }
 


### PR DESCRIPTION
Hi,
We've encountered a dependency problem in brson/rust-cookbook#192 due to outdated bitflags version here.