### PR TITLE
fix panic on incorrect code blocks

### DIFF
--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -352,6 +352,9 @@ pub fn scan_table_head(data: &str) -> (usize, Vec<Alignment>) {
 
 // returns: number of bytes scanned, char
 pub fn scan_code_fence(data: &str) -> (usize, u8) {
+    if data.is_empty() {
+        return (0, 0);
+    }
     let c = data.as_bytes()[0];
     if !(c == b'`' || c == b'~') { return (0, 0); }
     let i = 1 + scan_ch_repeat(&data[1 ..], c);

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,11 @@
+extern crate pulldown_cmark;
+
+#[test]
+fn test_wrong_code_block() {
+    let markdown = r##"```
+ * ```
+ "##;
+    use pulldown_cmark::{Parser};
+
+    let _ = Parser::new(&markdown);
+}


### PR DESCRIPTION
Due to an error in clippy, we wrongly parsed a `/**` comment as doc comment, leaving ` *` prefixes everywhere (see [issue #1920](https://github.com/rust-lang-nursery/rust-clippy/issues/1920). However, this trips up pulldown-cmark's scanner, which tries to get a byte from an empty slice.

This PR adds both a test case and a fix.