### PR TITLE
Handle Header Blocks for New Algorithm

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -541,8 +541,8 @@ impl<'a> RawParser<'a> {
             }
         };
         let n = scan_blank_line(&self.text[off..]);
-        if n.is_some() {
-            self.off = off + n.unwrap();
+        if let Some(n) = n {
+            self.off = off + n;
             return self.end();
         }
         self.state = State::TableRow;
@@ -644,10 +644,10 @@ impl<'a> RawParser<'a> {
 
         if self.fence_char == b'\0' {
             let n = scan_blank_line(&self.text[off..]);
-            if n.is_some() {
+            if let Some(n) = n {
                 // TODO performance: this scanning is O(n^2) in the number of empty lines
-                let (n_empty, _lines) = self.scan_empty_lines(&self.text[off + n.unwrap() ..]);
-                let next = off + n.unwrap() + n_empty;
+                let (n_empty, _lines) = self.scan_empty_lines(&self.text[off + n ..]);
+                let next = off + n + n_empty;
                 let (n_containers, scanned, nspace) = self.scan_containers(&self.text[next..]);
                 // TODO; handle space
                 if !scanned || self.is_code_block_end(next + n_containers, nspace) {

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -260,7 +260,25 @@ fn first_pass(s: &str) -> Tree<Item> {
             tree.push();
             let mut last_soft_break = None;
             while ix < s.len() {
-                ix += scan_whitespace_no_nl(&s[ix..]);
+                let (leading_bytes, leading_spaces) = scan_leading_space(&s[ix..], 0);
+                ix += leading_bytes;
+
+                // setext headers can interrupt paragraphs
+                let setext_bytes = scan_setext_header(&s[ix..]).0;
+                if setext_bytes > 0 && leading_spaces < 4 {
+                    break;
+                }
+                // thematic breaks can interrupt paragraphs
+                let hrule_bytes = scan_hrule(&s[ix..]);
+                if hrule_bytes > 0 && leading_spaces < 4 {
+                    break;
+                }
+                // atx headers can interrupt paragraphs
+                let atx_bytes = scan_atx_header(&s[ix..]).0;
+                if atx_bytes > 0 && leading_spaces < 4 {
+                    break;
+                }
+
                 if ix == s.len() || s.as_bytes()[ix] <= b' ' {
                     // EOF or empty line
                     break;

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -207,12 +207,16 @@ fn first_pass(s: &str) -> Tree<Item> {
                 while limit > 0 && header_text.as_bytes()[limit-1] == b' ' {
                     limit -= 1;
                 }
-                while limit > 0 && header_text.as_bytes()[limit-1] == b'#' {
-                    limit -= 1;
+                let mut closer = limit;
+                while closer > 0 && header_text.as_bytes()[closer-1] == b'#' {
+                    closer -= 1;
                 }
-                while limit > 0 && header_text.as_bytes()[limit-1] == b' ' {
-                    limit -= 1;
-                }
+                if closer > 0 && header_text.as_bytes()[closer-1] == b' ' {
+                    limit = closer;
+                    while limit > 0 && header_text.as_bytes()[limit-1] == b' ' {
+                        limit -= 1;
+                    }
+                } else if closer == 0 { limit = closer; }
                 if tree.cur != NIL {
                     tree.nodes[tree.cur].item.end = limit + header_start;
                 }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -225,7 +225,6 @@ fn first_pass(s: &str) -> Tree<Item> {
 
             let hrule_size = scan_hrule(&s[ix..]);
             if hrule_size > 0 && leading_spaces < 4 {
-                // println!("Found hrule");
                 tree.append(Item {
                     start: ix,
                     end: ix + hrule_size,

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -166,13 +166,12 @@ fn scan_trailing_codepoint(data: &str) -> Option<char> {
     }
 }
 
-// Maybe Option, size of 0 makes sense at EOF
-pub fn scan_blank_line(text: &str) -> usize {
+pub fn scan_blank_line(text: &str) -> Option<usize> {
     let i = scan_whitespace_no_nl(text);
     if let (n, true) = scan_eol(&text[i..]) {
-        i + n
+        Some(i + n)
     } else {
-        0
+        None
     }
 }
 
@@ -285,8 +284,8 @@ pub fn scan_setext_header(data: &str) -> (usize, i32) {
     if !(c == b'-' || c == b'=') { return (0, 0); }
     i += 1 + scan_ch_repeat(&data[i + 1 ..], c);
     let n = scan_blank_line(&data[i..]);
-    if n == 0 { return (0, 0); }
-    i += n;
+    if n.is_none() { return (0, 0); }
+    i += n.unwrap();
     let level = if c == b'=' { 1 } else { 2 };
     (i, level)
 }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -283,9 +283,11 @@ pub fn scan_setext_header(data: &str) -> (usize, i32) {
     let c = data.as_bytes()[i];
     if !(c == b'-' || c == b'=') { return (0, 0); }
     i += 1 + scan_ch_repeat(&data[i + 1 ..], c);
-    let n = scan_blank_line(&data[i..]);
-    if n.is_none() { return (0, 0); }
-    i += n.unwrap();
+    if let Some(n) = scan_blank_line(&data[i..]) {
+        i += n;
+    } else {
+        return (0, 0);
+    }
     let level = if c == b'=' { 1 } else { 2 };
     (i, level)
 }


### PR DESCRIPTION
The new algorithm now handles ATX Headers and Setext Headers. 

ATX Headers are handled in a similar way to the old algorithm.

Setext Headers are detected while parsing Paragraph nodes, and mutate the parent node to capture the paragraph text. Multiline Setext Headers are handled.

Spec tests for sections 4.1, 4.2, and 4.3 (Thematic Breaks, ATX Headers, and Setext Headers) are all passing, except those that rely on unimplemented blocks or escape characters. 

Now passing 189/621 spec tests.