### PR TITLE
Handle Indented and Fenced Code Blocks in new algorithm

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
             print!(" ");
         }
 
-        let our_html = render_html(&test.input.replace("→", "\t").replace("\n", "\r\n"), opts);
+        let our_html = render_html(&test.input.replace("→", "\t"), opts);
 
         if our_html == test.expected.replace("→", "\t") {
             print!(".");

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
             print!(" ");
         }
 
-        let our_html = render_html(&test.input.replace("→", "\t"), opts);
+        let our_html = render_html(&test.input.replace("→", "\t").replace("\n", "\r\n"), opts);
 
         if our_html == test.expected.replace("→", "\t") {
             print!(".");

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
         } else {
             if tests_failed == 0 {
                 print!("FAIL {}:\n\n---input---\n{}\n\n---wanted---\n{}\n\n---got---\n{}\n",
-                    test.n, test.input, test.expected, our_html.replace("\t","→"));
+                    test.n, test.input, test.expected, our_html.replace("\t", "→"));
             } else {
                 print!("X");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,12 +173,12 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
 
         let our_html = render_html(&test.input.replace("→", "\t").replace("\n", "\r\n"), opts);
 
-        if our_html == test.expected {
+        if our_html == test.expected.replace("→", "\t") {
             print!(".");
         } else {
             if tests_failed == 0 {
                 print!("FAIL {}:\n\n---input---\n{}\n\n---wanted---\n{}\n\n---got---\n{}\n",
-                    test.n, test.input, test.expected, our_html);
+                    test.n, test.input, test.expected, our_html.replace("\t","→"));
             } else {
                 print!("X");
             }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -179,21 +179,21 @@ fn parse_indented_code_block(tree : &mut Tree<Item>, s : &str, mut ix : usize) -
 
     while ix < s.len() {
         if let Some(codeline_start_offset) = scan_code_line(&s[ix..]) {
-            let (codeline_end_offset, is_eof) = scan_nextline_icb(&s[ix..]);
+
+            let codeline_end_offset = scan_line_ending(&s[ix..]);
             tree.append_text(codeline_start_offset + ix, codeline_end_offset + ix);
 
-            if is_eof {
-                tree.append(Item {
-                        start: codeline_end_offset,
-                        end: codeline_end_offset,
-                        body: ItemBody::SynthesizeNewLine,
-                });
-            }
+            tree.append(Item {
+                    start: codeline_end_offset,
+                    end: codeline_end_offset,
+                    body: ItemBody::SynthesizeNewLine,
+            });
 
             if scan_blank_line(&s[ix..]).is_none() {
                 last_chunk = tree.cur;
             }
             ix += codeline_end_offset;
+            ix += scan_eol(&s[ix..]).0;
         } else { // we've hit a non-indented line
             break;
         }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -159,7 +159,7 @@ fn parse_line(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     ix - start
 }
 
-fn parse_indented_code_block(tree : &mut Tree<Item>, s : &str, mut ix : usize) -> usize {
+fn parse_indented_code_block(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     let codeblock_parent = tree.cur;
     tree.append(Item {
             start: ix,
@@ -215,8 +215,8 @@ fn parse_indented_code_block(tree : &mut Tree<Item>, s : &str, mut ix : usize) -
     ix
 }
 
-fn parse_atx_header(mut tree : &mut Tree<Item>, s : &str, mut ix : usize,
-    atx_level : i32, atx_size : usize) -> usize {
+fn parse_atx_header(mut tree: &mut Tree<Item>, s: &str, mut ix: usize,
+    atx_level: i32, atx_size: usize) -> usize {
     
     tree.append(Item {
         start: ix,
@@ -268,7 +268,7 @@ fn parse_atx_header(mut tree : &mut Tree<Item>, s : &str, mut ix : usize,
     ix
 }
 
-fn parse_hrule(mut tree : &mut Tree<Item>, hrule_size : usize, mut ix : usize) -> usize {
+fn parse_hrule(mut tree: &mut Tree<Item>, hrule_size: usize, mut ix: usize) -> usize {
     tree.append(Item {
         start: ix,
         end: ix + hrule_size,
@@ -278,7 +278,7 @@ fn parse_hrule(mut tree : &mut Tree<Item>, hrule_size : usize, mut ix : usize) -
     ix
 }
 
-fn parse_code_fence_block(mut tree : &mut Tree<Item>, s : &str, mut ix : usize, indentation : usize) -> usize {
+fn parse_code_fence_block(mut tree: &mut Tree<Item>, s: &str, mut ix: usize, indentation: usize) -> usize {
     tree.append(Item {
         start: ix,
         end: 0, // set later
@@ -314,7 +314,7 @@ fn parse_code_fence_block(mut tree : &mut Tree<Item>, s : &str, mut ix : usize, 
     ix
 }
 
-fn parse_paragraph(mut tree : &mut Tree<Item>, s : &str, mut ix : usize) -> usize {
+fn parse_paragraph(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     tree.append(Item {
         start: ix,
         end: 0,  // will get set later

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -182,6 +182,13 @@ pub fn scan_nextline(s: &str) -> usize {
     }
 }
 
+pub fn scan_nextline_icb(s: &str) -> (usize, bool) {
+    match s.as_bytes().iter().position(|&c| c == b'\n') {
+        Some(x) => (x + 1, false),
+        None => (s.len(), true),
+    }
+}
+
 pub fn count_tab(bytes: &[u8]) -> usize {
     let mut count = 0;
     for &c in bytes.iter().rev() {
@@ -209,6 +216,25 @@ pub fn scan_leading_space(text: &str, loc: usize) -> (usize, usize) {
         i += 1
     }
     (i, spaces)
+}
+
+// return: start byte for code text in indented code line, or None
+// for a non-code line
+pub fn scan_code_line(text: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut num_spaces = 0;
+    let mut i = 0;
+    for &c in bytes {
+        if num_spaces == 4 { return Some(4); }
+        match c {
+            b' ' => num_spaces += 1,
+            b'\t' => { return Some(i+1); },
+            b'\n' | b'\r' => { return Some(i); }, 
+            _ => { return None; },
+        }
+        i += 1;
+    }
+    return None;
 }
 
 // returned pair is (number of bytes, number of spaces)

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -239,7 +239,7 @@ pub fn scan_code_line(text: &str) -> Option<usize> {
 
 // return: start byte for code text in fenced code line
 // of given indentation
-pub fn scan_fenced_code_line(text : &str, mut indentation : usize) -> usize {
+pub fn scan_fenced_code_line(text : &str, mut indentation: usize) -> usize {
     let bytes = text.as_bytes();
     let mut i = 0;
     for &c in bytes {
@@ -252,7 +252,7 @@ pub fn scan_fenced_code_line(text : &str, mut indentation : usize) -> usize {
 
 // return: end byte for closing code fence, or None
 // if the line is not a closing code fence
-pub fn scan_closing_code_fence(text : &str, fence_char : u8, num_fence_chars_req : usize) -> Option<usize> {
+pub fn scan_closing_code_fence(text: &str, fence_char: u8, num_fence_chars_req: usize) -> Option<usize> {
     let mut i = 0;
     let (num_leading_bytes, num_leading_spaces) = scan_leading_space(text, 0);
     if num_leading_spaces >= 4 { return None; }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -133,6 +133,13 @@ pub fn scan_eol(s: &str) -> (usize, bool) {
     }
 }
 
+pub fn scan_line_ending(s: &str) -> usize {
+    match s.as_bytes().iter().position(|&c| c == b'\r' || c == b'\n') {
+        Some(i) => i,
+        None => s.len()
+    }
+}
+
 // unusual among "scan" functions in that it scans from the _back_ of the string
 // TODO: should also scan unicode whitespace?
 pub fn scan_trailing_whitespace(data: &str) -> usize {
@@ -179,13 +186,6 @@ pub fn scan_nextline(s: &str) -> usize {
     match s.as_bytes().iter().position(|&c| c == b'\n') {
         Some(x) => x + 1,
         None => s.len()
-    }
-}
-
-pub fn scan_nextline_icb(s: &str) -> (usize, bool) {
-    match s.as_bytes().iter().position(|&c| c == b'\n') {
-        Some(x) => (x + 1, false),
-        None => (s.len(), true),
     }
 }
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -237,6 +237,35 @@ pub fn scan_code_line(text: &str) -> Option<usize> {
     return None;
 }
 
+// return: start byte for code text in fenced code line
+// of given indentation
+pub fn scan_fenced_code_line(text : &str, mut indentation : usize) -> usize {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    for &c in bytes {
+        if indentation == 0 || c != b' ' { return i; }
+        indentation -= 1;
+        i += 1;
+    }
+    i
+}
+
+// return: end byte for closing code fence, or None
+// if the line is not a closing code fence
+pub fn scan_closing_code_fence(text : &str, fence_char : u8, num_fence_chars_req : usize) -> Option<usize> {
+    let mut i = 0;
+    let (num_leading_bytes, num_leading_spaces) = scan_leading_space(text, 0);
+    if num_leading_spaces >= 4 { return None; }
+    i += num_leading_bytes;
+    let num_fence_chars_found = scan_ch_repeat(&text[i..], fence_char);
+    if num_fence_chars_found < num_fence_chars_req { return None; }
+    i += num_fence_chars_found;
+    let num_trailing_spaces = scan_ch_repeat(&text[i..], b' ');
+    i += num_trailing_spaces;
+    if scan_eol(&text[i..]).1 { return Some(i); }
+    return None;
+}
+
 // returned pair is (number of bytes, number of spaces)
 pub fn calc_indent(text: &str, max: usize) -> (usize, usize) {
     let bytes = text.as_bytes();
@@ -379,6 +408,7 @@ pub fn scan_table_head(data: &str) -> (usize, Vec<Alignment>) {
 
 // returns: number of bytes scanned, char
 pub fn scan_code_fence(data: &str) -> (usize, u8) {
+    if data.is_empty() { return (0,0); }
     let c = data.as_bytes()[0];
     if !(c == b'`' || c == b'~') { return (0, 0); }
     let i = 1 + scan_ch_repeat(&data[1 ..], c);


### PR DESCRIPTION
Now handling Indented Code Blocks in the new algorithm. Removal of trailing blank lines is handled by tree surgery in a way that is asymptotically faster than the master branch method.

I also made some changes to whitespace handling in the test harness. I'm pretty sure that the tab handling change is correct. I'm a little concerned that the change to carriage returns reduces the scope of the tests in an undesirable way, but I think that it was the correct thing to do because of the newline synthesis requirement for code blocks.