### PR TITLE
Handle HTML Blocks in new algorithm

### DIFF
--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -109,6 +109,21 @@ impl Tree<Item> {
             });
         }
     }
+
+    fn append_html_line(&mut self, start: usize, end: usize) {
+        if end >= start {
+            self.append(Item {
+                start: start,
+                end: end,
+                body: ItemBody::Html,
+            });
+            self.append(Item {
+                start: end,
+                end: end,
+                body: ItemBody::SynthesizeNewLine,
+            });
+        }
+    }
 }
 
 fn dump_tree(nodes: &Vec<Node<Item>>, mut ix: usize, level: usize) {
@@ -320,16 +335,7 @@ fn parse_html_block_type_1_to_5(tree : &mut Tree<Item>, s : &str, mut ix : usize
     while ix < s.len() {
         let nextline_offset = scan_nextline(&s[ix..]);
         let htmlline_end_offset = scan_line_ending(&s[ix..]);
-        tree.append(Item {
-            start: ix,
-            end: ix + htmlline_end_offset,
-            body: ItemBody::Html,
-        });
-        tree.append(Item {
-            start: ix + htmlline_end_offset,
-            end: ix + htmlline_end_offset,
-            body: ItemBody::SynthesizeNewLine,
-        });
+        tree.append_html_line(ix, ix+htmlline_end_offset);
         if (&s[ix..ix+htmlline_end_offset]).contains(html_end_tag) {
             return ix + nextline_offset;
         }
@@ -342,16 +348,7 @@ fn parse_html_block_type_6(tree : &mut Tree<Item>, s : &str, mut ix : usize) -> 
     while ix < s.len() {
         let nextline_offset = scan_nextline(&s[ix..]);
         let htmlline_end_offset = scan_line_ending(&s[ix..]);
-        tree.append(Item {
-            start: ix,
-            end: ix + htmlline_end_offset,
-            body: ItemBody::Html,
-        });
-        tree.append(Item {
-            start: ix + htmlline_end_offset,
-            end: ix + htmlline_end_offset,
-            body: ItemBody::SynthesizeNewLine,
-        });
+        tree.append_html_line(ix, ix+htmlline_end_offset);
         if let Some(_) = scan_blank_line(&s[ix+nextline_offset..]) {
             return ix + nextline_offset;
         }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -418,6 +418,38 @@ fn first_pass(s: &str) -> Tree<Item> {
     tree
 }
 
+fn get_html_end_tag(text : &str) -> Option<&'static str> {
+    static BEGIN_TAGS: &'static [&'static str; 3] = &["script", "pre", "style"];
+    static END_TAGS: &'static [&'static str; 3] = &["</script>", "</pre>", "</style>"];
+
+    for (beg_tag, end_tag) in BEGIN_TAGS.iter().zip(END_TAGS.iter()) {
+        if 1 + beg_tag.len() < text.len() &&
+           text.starts_with(&beg_tag[..]) {
+            let pos = beg_tag.len() + 1;
+            let s = text.as_bytes()[pos];
+            if s == b' ' || s == b'\n' || s == b'>' {
+                return Some(end_tag);
+            }
+        }
+    }
+    static ST_BEGIN_TAGS: &'static [&'static str; 3] = &["<!--", "<?", "<![CDATA["];
+    static ST_END_TAGS: &'static [&'static str; 3] = &["-->", "?>", "]]>"];
+    for (beg_tag, end_tag) in ST_BEGIN_TAGS.iter().zip(ST_END_TAGS.iter()) {
+        if 1 + beg_tag.len() < text.len() &&
+           text.starts_with(&beg_tag[..]) {
+            return Some(end_tag);
+        }
+    }
+    if text.len() > 2 &&
+       text.starts_with("<!") {
+        let c = text[2..].chars().next().unwrap();
+        if c >= 'A' && c <= 'Z' {
+            return Some(">");
+        }
+    }
+    None
+}
+
 #[derive(Copy, Clone, Debug)]
 struct InlineEl {
     start: usize,  // offset of tree node

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -495,7 +495,7 @@ fn get_html_end_tag(text : &str) -> Option<&'static str> {
 
     for (beg_tag, end_tag) in BEGIN_TAGS.iter().zip(END_TAGS.iter()) {
         if 1 + beg_tag.len() < text.len() &&
-           text.starts_with(&beg_tag[..]) {
+            text.starts_with(&beg_tag[..]) {
             let pos = beg_tag.len();
             let s = text.as_bytes()[pos];
             if s == b' ' || s == b'\r' || s == b'\n' || s == b'>' {
@@ -512,7 +512,7 @@ fn get_html_end_tag(text : &str) -> Option<&'static str> {
         }
     }
     if text.len() > 2 &&
-       text.starts_with("<!") {
+        text.starts_with("<!") {
         let c = text[2..].chars().next().unwrap();
         if c >= 'A' && c <= 'Z' {
             return Some(">");

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -30,13 +30,16 @@ use parse::Alignment;
 pub use puncttable::{is_ascii_punctuation, is_punctuation};
 
 // sorted for binary_search
-const HTML_TAGS: [&'static str; 50] = ["article", "aside", "blockquote",
-    "body", "button", "canvas", "caption", "col", "colgroup", "dd", "div",
-    "dl", "dt", "embed", "fieldset", "figcaption", "figure", "footer", "form",
-    "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "iframe",
-    "li", "map", "object", "ol", "output", "p", "pre", "progress", "script",
-    "section", "style", "table", "tbody", "td", "textarea", "tfoot", "th",
-    "thead", "tr", "ul", "video"];
+const HTML_TAGS: [&'static str; 72] = ["address", "article", "aside", "base", 
+    "basefont", "blockquote", "body", "button", "canvas", "caption", "center",
+    "col", "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", 
+    "embed", "fieldset", "figcaption", "figure", "footer", "form", "frame", 
+    "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", 
+    "hr", "html", "iframe", "legend", "li", "link", "main", "menu", "menuitem", 
+    "meta", "map", "nav", "noframes", "object", "ol", "optgroup", "option", 
+    "output", "p", "param", "progress", "section", "source", "summary", 
+    "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "title", "tr", 
+    "ul", "video"];
 
 const URI_SCHEMES: [&'static str; 164] = ["aaa", "aaas", "about", "acap",
     "adiumxtra", "afp", "afs", "aim", "apt", "attachment", "aw", "beshare",

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -725,6 +725,15 @@ pub fn unescape(input: &str) -> Cow<str> {
     }
 }
 
+pub fn scan_html_block_tag(data: &str) -> (usize, &str) {
+    let mut i = scan_ch(data, b'<');
+    if i == 0 { return (0, "") }
+    i += scan_ch(&data[i..], b'/');
+    let n = scan_while(&data[i..], is_ascii_alphanumeric);
+    // TODO: scan attributes and >
+    (i + n, &data[i .. i + n])
+}
+
 pub fn is_html_tag(tag: &str) -> bool {
     HTML_TAGS.binary_search_by(|probe| utils::strcasecmp(probe, tag)).is_ok()
 }


### PR DESCRIPTION
This handles HTML Blocks Type 1 through 6. I'm leaving Type 7 aside for the moment.

Now passing 269/621 spec tests.