### PR TITLE
Update spec tests & spec to commonmark 0.28

### DIFF
--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -2210,6 +2210,29 @@ bar
 
     #[test]
     fn spec_test_90() {
+        let original = r##"``
+foo
+``
+"##;
+        let expected = r##"<p><code>foo</code></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_91() {
         let original = r##"```
 aaa
 ~~~
@@ -2235,7 +2258,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_91() {
+    fn spec_test_92() {
         let original = r##"~~~
 aaa
 ```
@@ -2261,7 +2284,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_92() {
+    fn spec_test_93() {
         let original = r##"````
 aaa
 ```
@@ -2287,7 +2310,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_93() {
+    fn spec_test_94() {
         let original = r##"~~~~
 aaa
 ~~~
@@ -2313,7 +2336,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_94() {
+    fn spec_test_95() {
         let original = r##"```
 "##;
         let expected = r##"<pre><code></code></pre>
@@ -2334,7 +2357,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_95() {
+    fn spec_test_96() {
         let original = r##"`````
 
 ```
@@ -2361,7 +2384,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_96() {
+    fn spec_test_97() {
         let original = r##"> ```
 > aaa
 
@@ -2389,7 +2412,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_97() {
+    fn spec_test_98() {
         let original = r##"```
 
   
@@ -2415,7 +2438,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_98() {
+    fn spec_test_99() {
         let original = r##"```
 ```
 "##;
@@ -2437,7 +2460,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_99() {
+    fn spec_test_100() {
         let original = r##" ```
  aaa
 aaa
@@ -2463,7 +2486,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_100() {
+    fn spec_test_101() {
         let original = r##"  ```
 aaa
   aaa
@@ -2491,7 +2514,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_101() {
+    fn spec_test_102() {
         let original = r##"   ```
    aaa
     aaa
@@ -2519,7 +2542,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_102() {
+    fn spec_test_103() {
         let original = r##"    ```
     aaa
     ```
@@ -2545,32 +2568,8 @@ aaa
     }
 
     #[test]
-    fn spec_test_103() {
-        let original = r##"```
-aaa
-  ```
-"##;
-        let expected = r##"<pre><code>aaa
-</code></pre>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
     fn spec_test_104() {
-        let original = r##"   ```
+        let original = r##"```
 aaa
   ```
 "##;
@@ -2594,6 +2593,30 @@ aaa
 
     #[test]
     fn spec_test_105() {
+        let original = r##"   ```
+aaa
+  ```
+"##;
+        let expected = r##"<pre><code>aaa
+</code></pre>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_106() {
         let original = r##"```
 aaa
     ```
@@ -2618,7 +2641,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_106() {
+    fn spec_test_107() {
         let original = r##"``` ```
 aaa
 "##;
@@ -2641,7 +2664,7 @@ aaa</p>
     }
 
     #[test]
-    fn spec_test_107() {
+    fn spec_test_108() {
         let original = r##"~~~~~~
 aaa
 ~~~ ~~
@@ -2666,7 +2689,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_108() {
+    fn spec_test_109() {
         let original = r##"foo
 ```
 bar
@@ -2694,7 +2717,7 @@ baz
     }
 
     #[test]
-    fn spec_test_109() {
+    fn spec_test_110() {
         let original = r##"foo
 ---
 ~~~
@@ -2723,7 +2746,7 @@ bar
     }
 
     #[test]
-    fn spec_test_110() {
+    fn spec_test_111() {
         let original = r##"```ruby
 def foo(x)
   return 3
@@ -2751,7 +2774,7 @@ end
     }
 
     #[test]
-    fn spec_test_111() {
+    fn spec_test_112() {
         let original = r##"~~~~    ruby startline=3 $%@#$
 def foo(x)
   return 3
@@ -2779,7 +2802,7 @@ end
     }
 
     #[test]
-    fn spec_test_112() {
+    fn spec_test_113() {
         let original = r##"````;
 ````
 "##;
@@ -2801,7 +2824,7 @@ end
     }
 
     #[test]
-    fn spec_test_113() {
+    fn spec_test_114() {
         let original = r##"``` aa ```
 foo
 "##;
@@ -2824,7 +2847,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_114() {
+    fn spec_test_115() {
         let original = r##"```
 ``` aaa
 ```
@@ -2848,7 +2871,39 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_115() {
+    fn spec_test_116() {
+        let original = r##"<table><tr><td>
+<pre>
+**Hello**,
+
+_world_.
+</pre>
+</td></tr></table>
+"##;
+        let expected = r##"<table><tr><td>
+<pre>
+**Hello**,
+<p><em>world</em>.
+</pre></p>
+</td></tr></table>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_117() {
         let original = r##"<table>
   <tr>
     <td>
@@ -2884,7 +2939,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_116() {
+    fn spec_test_118() {
         let original = r##" <div>
   *hello*
          <foo><a>
@@ -2909,7 +2964,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_117() {
+    fn spec_test_119() {
         let original = r##"</div>
 *foo*
 "##;
@@ -2932,7 +2987,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_118() {
+    fn spec_test_120() {
         let original = r##"<DIV CLASS="foo">
 
 *Markdown*
@@ -2959,7 +3014,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_119() {
+    fn spec_test_121() {
         let original = r##"<div id="foo"
   class="bar">
 </div>
@@ -2984,7 +3039,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_120() {
+    fn spec_test_122() {
         let original = r##"<div id="foo" class="bar
   baz">
 </div>
@@ -3009,7 +3064,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_121() {
+    fn spec_test_123() {
         let original = r##"<div>
 *foo*
 
@@ -3035,7 +3090,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_122() {
+    fn spec_test_124() {
         let original = r##"<div id="foo"
 *hi*
 "##;
@@ -3058,7 +3113,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_123() {
+    fn spec_test_125() {
         let original = r##"<div class
 foo
 "##;
@@ -3081,7 +3136,7 @@ foo
     }
 
     #[test]
-    fn spec_test_124() {
+    fn spec_test_126() {
         let original = r##"<div *???-&&&-<---
 *foo*
 "##;
@@ -3104,7 +3159,7 @@ foo
     }
 
     #[test]
-    fn spec_test_125() {
+    fn spec_test_127() {
         let original = r##"<div><a href="bar">*foo*</a></div>
 "##;
         let expected = r##"<div><a href="bar">*foo*</a></div>
@@ -3125,7 +3180,7 @@ foo
     }
 
     #[test]
-    fn spec_test_126() {
+    fn spec_test_128() {
         let original = r##"<table><tr><td>
 foo
 </td></tr></table>
@@ -3150,7 +3205,7 @@ foo
     }
 
     #[test]
-    fn spec_test_127() {
+    fn spec_test_129() {
         let original = r##"<div></div>
 ``` c
 int x = 33;
@@ -3177,7 +3232,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_128() {
+    fn spec_test_130() {
         let original = r##"<a href="foo">
 *bar*
 </a>
@@ -3202,7 +3257,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_129() {
+    fn spec_test_131() {
         let original = r##"<Warning>
 *bar*
 </Warning>
@@ -3227,7 +3282,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_130() {
+    fn spec_test_132() {
         let original = r##"<i class="foo">
 *bar*
 </i>
@@ -3252,7 +3307,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_131() {
+    fn spec_test_133() {
         let original = r##"</ins>
 *bar*
 "##;
@@ -3275,7 +3330,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_132() {
+    fn spec_test_134() {
         let original = r##"<del>
 *foo*
 </del>
@@ -3300,7 +3355,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_133() {
+    fn spec_test_135() {
         let original = r##"<del>
 
 *foo*
@@ -3327,7 +3382,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_134() {
+    fn spec_test_136() {
         let original = r##"<del>*foo*</del>
 "##;
         let expected = r##"<p><del><em>foo</em></del></p>
@@ -3348,7 +3403,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_135() {
+    fn spec_test_137() {
         let original = r##"<pre language="haskell"><code>
 import Text.HTML.TagSoup
 
@@ -3381,7 +3436,7 @@ main = print $ parseTags tags
     }
 
     #[test]
-    fn spec_test_136() {
+    fn spec_test_138() {
         let original = r##"<script type="text/javascript">
 // JavaScript example
 
@@ -3412,7 +3467,7 @@ document.getElementById("demo").innerHTML = "Hello JavaScript!";
     }
 
     #[test]
-    fn spec_test_137() {
+    fn spec_test_139() {
         let original = r##"<style
   type="text/css">
 h1 {color:red;}
@@ -3445,7 +3500,7 @@ p {color:blue;}
     }
 
     #[test]
-    fn spec_test_138() {
+    fn spec_test_140() {
         let original = r##"<style
   type="text/css">
 
@@ -3472,7 +3527,7 @@ foo
     }
 
     #[test]
-    fn spec_test_139() {
+    fn spec_test_141() {
         let original = r##"> <div>
 > foo
 
@@ -3500,7 +3555,7 @@ foo
     }
 
     #[test]
-    fn spec_test_140() {
+    fn spec_test_142() {
         let original = r##"- <div>
 - foo
 "##;
@@ -3527,7 +3582,7 @@ foo
     }
 
     #[test]
-    fn spec_test_141() {
+    fn spec_test_143() {
         let original = r##"<style>p{color:red;}</style>
 *foo*
 "##;
@@ -3550,7 +3605,7 @@ foo
     }
 
     #[test]
-    fn spec_test_142() {
+    fn spec_test_144() {
         let original = r##"<!-- foo -->*bar*
 *baz*
 "##;
@@ -3573,7 +3628,7 @@ foo
     }
 
     #[test]
-    fn spec_test_143() {
+    fn spec_test_145() {
         let original = r##"<script>
 foo
 </script>1. *bar*
@@ -3598,7 +3653,7 @@ foo
     }
 
     #[test]
-    fn spec_test_144() {
+    fn spec_test_146() {
         let original = r##"<!-- Foo
 
 bar
@@ -3627,7 +3682,7 @@ bar
     }
 
     #[test]
-    fn spec_test_145() {
+    fn spec_test_147() {
         let original = r##"<?php
 
   echo '>';
@@ -3658,7 +3713,7 @@ okay
     }
 
     #[test]
-    fn spec_test_146() {
+    fn spec_test_148() {
         let original = r##"<!DOCTYPE html>
 "##;
         let expected = r##"<!DOCTYPE html>
@@ -3679,7 +3734,7 @@ okay
     }
 
     #[test]
-    fn spec_test_147() {
+    fn spec_test_149() {
         let original = r##"<![CDATA[
 function matchwo(a,b)
 {
@@ -3724,7 +3779,7 @@ function matchwo(a,b)
     }
 
     #[test]
-    fn spec_test_148() {
+    fn spec_test_150() {
         let original = r##"  <!-- foo -->
 
     <!-- foo -->
@@ -3749,7 +3804,7 @@ function matchwo(a,b)
     }
 
     #[test]
-    fn spec_test_149() {
+    fn spec_test_151() {
         let original = r##"  <div>
 
     <div>
@@ -3774,7 +3829,7 @@ function matchwo(a,b)
     }
 
     #[test]
-    fn spec_test_150() {
+    fn spec_test_152() {
         let original = r##"Foo
 <div>
 bar
@@ -3801,7 +3856,7 @@ bar
     }
 
     #[test]
-    fn spec_test_151() {
+    fn spec_test_153() {
         let original = r##"<div>
 bar
 </div>
@@ -3828,7 +3883,7 @@ bar
     }
 
     #[test]
-    fn spec_test_152() {
+    fn spec_test_154() {
         let original = r##"Foo
 <a href="bar">
 baz
@@ -3853,7 +3908,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_153() {
+    fn spec_test_155() {
         let original = r##"<div>
 
 *Emphasized* text.
@@ -3880,7 +3935,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_154() {
+    fn spec_test_156() {
         let original = r##"<div>
 *Emphasized* text.
 </div>
@@ -3905,7 +3960,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_155() {
+    fn spec_test_157() {
         let original = r##"<table>
 
 <tr>
@@ -3942,7 +3997,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_156() {
+    fn spec_test_158() {
         let original = r##"<table>
 
   <tr>
@@ -3980,7 +4035,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_157() {
+    fn spec_test_159() {
         let original = r##"[foo]: /url "title"
 
 [foo]
@@ -4003,7 +4058,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_158() {
+    fn spec_test_160() {
         let original = r##"   [foo]: 
       /url  
            'the title'  
@@ -4028,7 +4083,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_159() {
+    fn spec_test_161() {
         let original = r##"[Foo*bar\]]:my_(url) 'title (with parens)'
 
 [Foo*bar\]]
@@ -4051,7 +4106,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_160() {
+    fn spec_test_162() {
         let original = r##"[Foo bar]:
 <my%20url>
 'title'
@@ -4076,7 +4131,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_161() {
+    fn spec_test_163() {
         let original = r##"[foo]: /url '
 title
 line1
@@ -4107,7 +4162,7 @@ line2
     }
 
     #[test]
-    fn spec_test_162() {
+    fn spec_test_164() {
         let original = r##"[foo]: /url 'title
 
 with blank line'
@@ -4134,7 +4189,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_163() {
+    fn spec_test_165() {
         let original = r##"[foo]:
 /url
 
@@ -4158,7 +4213,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_164() {
+    fn spec_test_166() {
         let original = r##"[foo]:
 
 [foo]
@@ -4182,7 +4237,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_165() {
+    fn spec_test_167() {
         let original = r##"[foo]: /url\bar\*baz "foo\"bar\baz"
 
 [foo]
@@ -4205,7 +4260,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_166() {
+    fn spec_test_168() {
         let original = r##"[foo]
 
 [foo]: url
@@ -4228,7 +4283,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_167() {
+    fn spec_test_169() {
         let original = r##"[foo]
 
 [foo]: first
@@ -4252,7 +4307,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_168() {
+    fn spec_test_170() {
         let original = r##"[FOO]: /url
 
 [Foo]
@@ -4275,7 +4330,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_169() {
+    fn spec_test_171() {
         let original = r##"[ΑΓΩ]: /φου
 
 [αγω]
@@ -4298,7 +4353,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_170() {
+    fn spec_test_172() {
         let original = r##"[foo]: /url
 "##;
         let expected = r##""##;
@@ -4318,7 +4373,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_171() {
+    fn spec_test_173() {
         let original = r##"[
 foo
 ]: /url
@@ -4342,7 +4397,7 @@ bar
     }
 
     #[test]
-    fn spec_test_172() {
+    fn spec_test_174() {
         let original = r##"[foo]: /url "title" ok
 "##;
         let expected = r##"<p>[foo]: /url &quot;title&quot; ok</p>
@@ -4363,7 +4418,7 @@ bar
     }
 
     #[test]
-    fn spec_test_173() {
+    fn spec_test_175() {
         let original = r##"[foo]: /url
 "title" ok
 "##;
@@ -4385,7 +4440,7 @@ bar
     }
 
     #[test]
-    fn spec_test_174() {
+    fn spec_test_176() {
         let original = r##"    [foo]: /url "title"
 
 [foo]
@@ -4410,7 +4465,7 @@ bar
     }
 
     #[test]
-    fn spec_test_175() {
+    fn spec_test_177() {
         let original = r##"```
 [foo]: /url
 ```
@@ -4437,7 +4492,7 @@ bar
     }
 
     #[test]
-    fn spec_test_176() {
+    fn spec_test_178() {
         let original = r##"Foo
 [bar]: /baz
 
@@ -4463,7 +4518,7 @@ bar
     }
 
     #[test]
-    fn spec_test_177() {
+    fn spec_test_179() {
         let original = r##"# [Foo]
 [foo]: /url
 > bar
@@ -4489,7 +4544,7 @@ bar
     }
 
     #[test]
-    fn spec_test_178() {
+    fn spec_test_180() {
         let original = r##"[foo]: /foo-url "foo"
 [bar]: /bar-url
   "bar"
@@ -4519,7 +4574,7 @@ bar
     }
 
     #[test]
-    fn spec_test_179() {
+    fn spec_test_181() {
         let original = r##"[foo]
 
 > [foo]: /url
@@ -4544,7 +4599,7 @@ bar
     }
 
     #[test]
-    fn spec_test_180() {
+    fn spec_test_182() {
         let original = r##"aaa
 
 bbb
@@ -4568,7 +4623,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_181() {
+    fn spec_test_183() {
         let original = r##"aaa
 bbb
 
@@ -4596,7 +4651,7 @@ ddd</p>
     }
 
     #[test]
-    fn spec_test_182() {
+    fn spec_test_184() {
         let original = r##"aaa
 
 
@@ -4621,7 +4676,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_183() {
+    fn spec_test_185() {
         let original = r##"  aaa
  bbb
 "##;
@@ -4644,7 +4699,7 @@ bbb</p>
     }
 
     #[test]
-    fn spec_test_184() {
+    fn spec_test_186() {
         let original = r##"aaa
              bbb
                                        ccc
@@ -4669,7 +4724,7 @@ ccc</p>
     }
 
     #[test]
-    fn spec_test_185() {
+    fn spec_test_187() {
         let original = r##"   aaa
 bbb
 "##;
@@ -4692,7 +4747,7 @@ bbb</p>
     }
 
     #[test]
-    fn spec_test_186() {
+    fn spec_test_188() {
         let original = r##"    aaa
 bbb
 "##;
@@ -4716,7 +4771,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_187() {
+    fn spec_test_189() {
         let original = r##"aaa     
 bbb     
 "##;
@@ -4739,7 +4794,7 @@ bbb</p>
     }
 
     #[test]
-    fn spec_test_188() {
+    fn spec_test_190() {
         let original = r##"  
 
 aaa
@@ -4768,7 +4823,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_189() {
+    fn spec_test_191() {
         let original = r##"> # Foo
 > bar
 > baz
@@ -4795,7 +4850,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_190() {
+    fn spec_test_192() {
         let original = r##"># Foo
 >bar
 > baz
@@ -4822,7 +4877,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_191() {
+    fn spec_test_193() {
         let original = r##"   > # Foo
    > bar
  > baz
@@ -4849,7 +4904,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_192() {
+    fn spec_test_194() {
         let original = r##"    > # Foo
     > bar
     > baz
@@ -4875,7 +4930,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_193() {
+    fn spec_test_195() {
         let original = r##"> # Foo
 > bar
 baz
@@ -4902,7 +4957,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_194() {
+    fn spec_test_196() {
         let original = r##"> bar
 baz
 > foo
@@ -4929,7 +4984,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_195() {
+    fn spec_test_197() {
         let original = r##"> foo
 ---
 "##;
@@ -4954,7 +5009,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_196() {
+    fn spec_test_198() {
         let original = r##"> - foo
 - bar
 "##;
@@ -4983,7 +5038,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_197() {
+    fn spec_test_199() {
         let original = r##">     foo
     bar
 "##;
@@ -5010,7 +5065,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_198() {
+    fn spec_test_200() {
         let original = r##"> ```
 foo
 ```
@@ -5037,7 +5092,7 @@ foo
     }
 
     #[test]
-    fn spec_test_199() {
+    fn spec_test_201() {
         let original = r##"> foo
     - bar
 "##;
@@ -5062,7 +5117,7 @@ foo
     }
 
     #[test]
-    fn spec_test_200() {
+    fn spec_test_202() {
         let original = r##">
 "##;
         let expected = r##"<blockquote>
@@ -5084,7 +5139,7 @@ foo
     }
 
     #[test]
-    fn spec_test_201() {
+    fn spec_test_203() {
         let original = r##">
 >  
 > 
@@ -5108,7 +5163,7 @@ foo
     }
 
     #[test]
-    fn spec_test_202() {
+    fn spec_test_204() {
         let original = r##">
 > foo
 >  
@@ -5133,7 +5188,7 @@ foo
     }
 
     #[test]
-    fn spec_test_203() {
+    fn spec_test_205() {
         let original = r##"> foo
 
 > bar
@@ -5161,7 +5216,7 @@ foo
     }
 
     #[test]
-    fn spec_test_204() {
+    fn spec_test_206() {
         let original = r##"> foo
 > bar
 "##;
@@ -5186,7 +5241,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_205() {
+    fn spec_test_207() {
         let original = r##"> foo
 >
 > bar
@@ -5212,7 +5267,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_206() {
+    fn spec_test_208() {
         let original = r##"foo
 > bar
 "##;
@@ -5237,7 +5292,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_207() {
+    fn spec_test_209() {
         let original = r##"> aaa
 ***
 > bbb
@@ -5266,7 +5321,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_208() {
+    fn spec_test_210() {
         let original = r##"> bar
 baz
 "##;
@@ -5291,7 +5346,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_209() {
+    fn spec_test_211() {
         let original = r##"> bar
 
 baz
@@ -5317,7 +5372,7 @@ baz
     }
 
     #[test]
-    fn spec_test_210() {
+    fn spec_test_212() {
         let original = r##"> bar
 >
 baz
@@ -5343,7 +5398,7 @@ baz
     }
 
     #[test]
-    fn spec_test_211() {
+    fn spec_test_213() {
         let original = r##"> > > foo
 bar
 "##;
@@ -5372,7 +5427,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_212() {
+    fn spec_test_214() {
         let original = r##">>> foo
 > bar
 >>baz
@@ -5403,7 +5458,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_213() {
+    fn spec_test_215() {
         let original = r##">     code
 
 >    not code
@@ -5432,7 +5487,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_214() {
+    fn spec_test_216() {
         let original = r##"A paragraph
 with two lines.
 
@@ -5464,7 +5519,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_215() {
+    fn spec_test_217() {
         let original = r##"1.  A paragraph
     with two lines.
 
@@ -5500,7 +5555,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_216() {
+    fn spec_test_218() {
         let original = r##"- one
 
  two
@@ -5526,7 +5581,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_217() {
+    fn spec_test_219() {
         let original = r##"- one
 
   two
@@ -5554,7 +5609,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_218() {
+    fn spec_test_220() {
         let original = r##" -    one
 
      two
@@ -5581,7 +5636,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_219() {
+    fn spec_test_221() {
         let original = r##" -    one
 
       two
@@ -5609,7 +5664,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_220() {
+    fn spec_test_222() {
         let original = r##"   > > 1.  one
 >>
 >>     two
@@ -5641,7 +5696,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_221() {
+    fn spec_test_223() {
         let original = r##">>- one
 >>
   >  > two
@@ -5671,7 +5726,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_222() {
+    fn spec_test_224() {
         let original = r##"-one
 
 2.two
@@ -5695,7 +5750,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_223() {
+    fn spec_test_225() {
         let original = r##"- foo
 
 
@@ -5724,7 +5779,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_224() {
+    fn spec_test_226() {
         let original = r##"1.  foo
 
     ```
@@ -5763,7 +5818,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_225() {
+    fn spec_test_227() {
         let original = r##"- Foo
 
       bar
@@ -5798,7 +5853,7 @@ baz
     }
 
     #[test]
-    fn spec_test_226() {
+    fn spec_test_228() {
         let original = r##"123456789. ok
 "##;
         let expected = r##"<ol start="123456789">
@@ -5821,7 +5876,7 @@ baz
     }
 
     #[test]
-    fn spec_test_227() {
+    fn spec_test_229() {
         let original = r##"1234567890. not ok
 "##;
         let expected = r##"<p>1234567890. not ok</p>
@@ -5842,7 +5897,7 @@ baz
     }
 
     #[test]
-    fn spec_test_228() {
+    fn spec_test_230() {
         let original = r##"0. ok
 "##;
         let expected = r##"<ol start="0">
@@ -5865,7 +5920,7 @@ baz
     }
 
     #[test]
-    fn spec_test_229() {
+    fn spec_test_231() {
         let original = r##"003. ok
 "##;
         let expected = r##"<ol start="3">
@@ -5888,7 +5943,7 @@ baz
     }
 
     #[test]
-    fn spec_test_230() {
+    fn spec_test_232() {
         let original = r##"-1. not ok
 "##;
         let expected = r##"<p>-1. not ok</p>
@@ -5909,7 +5964,7 @@ baz
     }
 
     #[test]
-    fn spec_test_231() {
+    fn spec_test_233() {
         let original = r##"- foo
 
       bar
@@ -5938,7 +5993,7 @@ baz
     }
 
     #[test]
-    fn spec_test_232() {
+    fn spec_test_234() {
         let original = r##"  10.  foo
 
            bar
@@ -5967,7 +6022,7 @@ baz
     }
 
     #[test]
-    fn spec_test_233() {
+    fn spec_test_235() {
         let original = r##"    indented code
 
 paragraph
@@ -5996,7 +6051,7 @@ paragraph
     }
 
     #[test]
-    fn spec_test_234() {
+    fn spec_test_236() {
         let original = r##"1.     indented code
 
    paragraph
@@ -6029,7 +6084,7 @@ paragraph
     }
 
     #[test]
-    fn spec_test_235() {
+    fn spec_test_237() {
         let original = r##"1.      indented code
 
    paragraph
@@ -6062,7 +6117,7 @@ paragraph
     }
 
     #[test]
-    fn spec_test_236() {
+    fn spec_test_238() {
         let original = r##"   foo
 
 bar
@@ -6086,7 +6141,7 @@ bar
     }
 
     #[test]
-    fn spec_test_237() {
+    fn spec_test_239() {
         let original = r##"-    foo
 
   bar
@@ -6112,7 +6167,7 @@ bar
     }
 
     #[test]
-    fn spec_test_238() {
+    fn spec_test_240() {
         let original = r##"-  foo
 
    bar
@@ -6140,7 +6195,7 @@ bar
     }
 
     #[test]
-    fn spec_test_239() {
+    fn spec_test_241() {
         let original = r##"-
   foo
 -
@@ -6178,7 +6233,7 @@ bar
     }
 
     #[test]
-    fn spec_test_240() {
+    fn spec_test_242() {
         let original = r##"-   
   foo
 "##;
@@ -6202,7 +6257,7 @@ bar
     }
 
     #[test]
-    fn spec_test_241() {
+    fn spec_test_243() {
         let original = r##"-
 
   foo
@@ -6228,7 +6283,7 @@ bar
     }
 
     #[test]
-    fn spec_test_242() {
+    fn spec_test_244() {
         let original = r##"- foo
 -
 - bar
@@ -6255,7 +6310,7 @@ bar
     }
 
     #[test]
-    fn spec_test_243() {
+    fn spec_test_245() {
         let original = r##"- foo
 -   
 - bar
@@ -6282,7 +6337,7 @@ bar
     }
 
     #[test]
-    fn spec_test_244() {
+    fn spec_test_246() {
         let original = r##"1. foo
 2.
 3. bar
@@ -6309,7 +6364,7 @@ bar
     }
 
     #[test]
-    fn spec_test_245() {
+    fn spec_test_247() {
         let original = r##"*
 "##;
         let expected = r##"<ul>
@@ -6332,7 +6387,7 @@ bar
     }
 
     #[test]
-    fn spec_test_246() {
+    fn spec_test_248() {
         let original = r##"foo
 *
 
@@ -6360,7 +6415,7 @@ foo
     }
 
     #[test]
-    fn spec_test_247() {
+    fn spec_test_249() {
         let original = r##" 1.  A paragraph
      with two lines.
 
@@ -6396,7 +6451,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_248() {
+    fn spec_test_250() {
         let original = r##"  1.  A paragraph
       with two lines.
 
@@ -6432,7 +6487,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_249() {
+    fn spec_test_251() {
         let original = r##"   1.  A paragraph
        with two lines.
 
@@ -6468,7 +6523,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_250() {
+    fn spec_test_252() {
         let original = r##"    1.  A paragraph
         with two lines.
 
@@ -6500,7 +6555,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_251() {
+    fn spec_test_253() {
         let original = r##"  1.  A paragraph
 with two lines.
 
@@ -6536,7 +6591,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_252() {
+    fn spec_test_254() {
         let original = r##"  1.  A paragraph
     with two lines.
 "##;
@@ -6561,7 +6616,7 @@ with two lines.</li>
     }
 
     #[test]
-    fn spec_test_253() {
+    fn spec_test_255() {
         let original = r##"> 1. > Blockquote
 continued here.
 "##;
@@ -6592,7 +6647,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_254() {
+    fn spec_test_256() {
         let original = r##"> 1. > Blockquote
 > continued here.
 "##;
@@ -6623,7 +6678,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_255() {
+    fn spec_test_257() {
         let original = r##"- foo
   - bar
     - baz
@@ -6661,7 +6716,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_256() {
+    fn spec_test_258() {
         let original = r##"- foo
  - bar
   - baz
@@ -6690,7 +6745,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_257() {
+    fn spec_test_259() {
         let original = r##"10) foo
     - bar
 "##;
@@ -6718,7 +6773,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_258() {
+    fn spec_test_260() {
         let original = r##"10) foo
    - bar
 "##;
@@ -6745,7 +6800,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_259() {
+    fn spec_test_261() {
         let original = r##"- - foo
 "##;
         let expected = r##"<ul>
@@ -6772,7 +6827,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_260() {
+    fn spec_test_262() {
         let original = r##"1. - 2. foo
 "##;
         let expected = r##"<ol>
@@ -6803,7 +6858,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_261() {
+    fn spec_test_263() {
         let original = r##"- # Foo
 - Bar
   ---
@@ -6834,7 +6889,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_262() {
+    fn spec_test_264() {
         let original = r##"- foo
 - bar
 + baz
@@ -6863,7 +6918,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_263() {
+    fn spec_test_265() {
         let original = r##"1. foo
 2. bar
 3) baz
@@ -6892,7 +6947,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_264() {
+    fn spec_test_266() {
         let original = r##"Foo
 - bar
 - baz
@@ -6919,7 +6974,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_265() {
+    fn spec_test_267() {
         let original = r##"The number of windows in my house is
 14.  The number of doors is 6.
 "##;
@@ -6942,7 +6997,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_266() {
+    fn spec_test_268() {
         let original = r##"The number of windows in my house is
 1.  The number of doors is 6.
 "##;
@@ -6967,7 +7022,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_267() {
+    fn spec_test_269() {
         let original = r##"- foo
 
 - bar
@@ -7003,7 +7058,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_268() {
+    fn spec_test_270() {
         let original = r##"- foo
   - bar
     - baz
@@ -7042,7 +7097,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_269() {
+    fn spec_test_271() {
         let original = r##"- foo
 - bar
 
@@ -7077,7 +7132,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_270() {
+    fn spec_test_272() {
         let original = r##"-   foo
 
     notcode
@@ -7117,7 +7172,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_271() {
+    fn spec_test_273() {
         let original = r##"- a
  - b
   - c
@@ -7156,7 +7211,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_272() {
+    fn spec_test_274() {
         let original = r##"1. a
 
   2. b
@@ -7191,7 +7246,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_273() {
+    fn spec_test_275() {
         let original = r##"- a
 - b
 
@@ -7225,7 +7280,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_274() {
+    fn spec_test_276() {
         let original = r##"* a
 *
 
@@ -7257,7 +7312,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_275() {
+    fn spec_test_277() {
         let original = r##"- a
 - b
 
@@ -7293,7 +7348,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_276() {
+    fn spec_test_278() {
         let original = r##"- a
 - b
 
@@ -7328,7 +7383,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_277() {
+    fn spec_test_279() {
         let original = r##"- a
 - ```
   b
@@ -7364,7 +7419,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_278() {
+    fn spec_test_280() {
         let original = r##"- a
   - b
 
@@ -7399,7 +7454,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_279() {
+    fn spec_test_281() {
         let original = r##"* a
   > b
   >
@@ -7430,7 +7485,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_280() {
+    fn spec_test_282() {
         let original = r##"- a
   > b
   ```
@@ -7465,7 +7520,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_281() {
+    fn spec_test_283() {
         let original = r##"- a
 "##;
         let expected = r##"<ul>
@@ -7488,7 +7543,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_282() {
+    fn spec_test_284() {
         let original = r##"- a
   - b
 "##;
@@ -7516,7 +7571,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_283() {
+    fn spec_test_285() {
         let original = r##"1. ```
    foo
    ```
@@ -7547,7 +7602,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_284() {
+    fn spec_test_286() {
         let original = r##"* foo
   * bar
 
@@ -7579,7 +7634,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_285() {
+    fn spec_test_287() {
         let original = r##"- a
   - b
   - c
@@ -7621,7 +7676,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_286() {
+    fn spec_test_288() {
         let original = r##"`hi`lo`
 "##;
         let expected = r##"<p><code>hi</code>lo`</p>
@@ -7642,7 +7697,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_287() {
+    fn spec_test_289() {
         let original = r##"\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
 "##;
         let expected = r##"<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
@@ -7663,7 +7718,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_288() {
+    fn spec_test_290() {
         let original = r##"\	\A\a\ \3\φ\«
 "##;
         let expected = r##"<p>\	\A\a\ \3\φ\«</p>
@@ -7684,7 +7739,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_289() {
+    fn spec_test_291() {
         let original = r##"\*not emphasized*
 \<br/> not a tag
 \[not a link](/foo)
@@ -7719,7 +7774,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_290() {
+    fn spec_test_292() {
         let original = r##"\\*emphasis*
 "##;
         let expected = r##"<p>\<em>emphasis</em></p>
@@ -7740,7 +7795,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_291() {
+    fn spec_test_293() {
         let original = r##"foo\
 bar
 "##;
@@ -7763,7 +7818,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_292() {
+    fn spec_test_294() {
         let original = r##"`` \[\` ``
 "##;
         let expected = r##"<p><code>\[\`</code></p>
@@ -7784,7 +7839,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_293() {
+    fn spec_test_295() {
         let original = r##"    \[\]
 "##;
         let expected = r##"<pre><code>\[\]
@@ -7806,7 +7861,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_294() {
+    fn spec_test_296() {
         let original = r##"~~~
 \[\]
 ~~~
@@ -7830,7 +7885,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_295() {
+    fn spec_test_297() {
         let original = r##"<http://example.com?find=\*>
 "##;
         let expected = r##"<p><a href="http://example.com?find=%5C*">http://example.com?find=\*</a></p>
@@ -7851,7 +7906,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_296() {
+    fn spec_test_298() {
         let original = r##"<a href="/bar\/)">
 "##;
         let expected = r##"<a href="/bar\/)">
@@ -7872,7 +7927,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_297() {
+    fn spec_test_299() {
         let original = r##"[foo](/bar\* "ti\*tle")
 "##;
         let expected = r##"<p><a href="/bar*" title="ti*tle">foo</a></p>
@@ -7893,7 +7948,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_298() {
+    fn spec_test_300() {
         let original = r##"[foo]
 
 [foo]: /bar\* "ti\*tle"
@@ -7916,7 +7971,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_299() {
+    fn spec_test_301() {
         let original = r##"``` foo\+bar
 foo
 ```
@@ -7940,7 +7995,7 @@ foo
     }
 
     #[test]
-    fn spec_test_300() {
+    fn spec_test_302() {
         let original = r##"&nbsp; &amp; &copy; &AElig; &Dcaron;
 &frac34; &HilbertSpace; &DifferentialD;
 &ClockwiseContourIntegral; &ngE;
@@ -7965,7 +8020,7 @@ foo
     }
 
     #[test]
-    fn spec_test_301() {
+    fn spec_test_303() {
         let original = r##"&#35; &#1234; &#992; &#98765432; &#0;
 "##;
         let expected = r##"<p># Ӓ Ϡ � �</p>
@@ -7986,7 +8041,7 @@ foo
     }
 
     #[test]
-    fn spec_test_302() {
+    fn spec_test_304() {
         let original = r##"&#X22; &#XD06; &#xcab;
 "##;
         let expected = r##"<p>&quot; ആ ಫ</p>
@@ -8007,7 +8062,7 @@ foo
     }
 
     #[test]
-    fn spec_test_303() {
+    fn spec_test_305() {
         let original = r##"&nbsp &x; &#; &#x;
 &ThisIsNotDefined; &hi?;
 "##;
@@ -8030,7 +8085,7 @@ foo
     }
 
     #[test]
-    fn spec_test_304() {
+    fn spec_test_306() {
         let original = r##"&copy
 "##;
         let expected = r##"<p>&amp;copy</p>
@@ -8051,7 +8106,7 @@ foo
     }
 
     #[test]
-    fn spec_test_305() {
+    fn spec_test_307() {
         let original = r##"&MadeUpEntity;
 "##;
         let expected = r##"<p>&amp;MadeUpEntity;</p>
@@ -8072,7 +8127,7 @@ foo
     }
 
     #[test]
-    fn spec_test_306() {
+    fn spec_test_308() {
         let original = r##"<a href="&ouml;&ouml;.html">
 "##;
         let expected = r##"<a href="&ouml;&ouml;.html">
@@ -8093,7 +8148,7 @@ foo
     }
 
     #[test]
-    fn spec_test_307() {
+    fn spec_test_309() {
         let original = r##"[foo](/f&ouml;&ouml; "f&ouml;&ouml;")
 "##;
         let expected = r##"<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
@@ -8114,7 +8169,7 @@ foo
     }
 
     #[test]
-    fn spec_test_308() {
+    fn spec_test_310() {
         let original = r##"[foo]
 
 [foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
@@ -8137,7 +8192,7 @@ foo
     }
 
     #[test]
-    fn spec_test_309() {
+    fn spec_test_311() {
         let original = r##"``` f&ouml;&ouml;
 foo
 ```
@@ -8161,7 +8216,7 @@ foo
     }
 
     #[test]
-    fn spec_test_310() {
+    fn spec_test_312() {
         let original = r##"`f&ouml;&ouml;`
 "##;
         let expected = r##"<p><code>f&amp;ouml;&amp;ouml;</code></p>
@@ -8182,7 +8237,7 @@ foo
     }
 
     #[test]
-    fn spec_test_311() {
+    fn spec_test_313() {
         let original = r##"    f&ouml;f&ouml;
 "##;
         let expected = r##"<pre><code>f&amp;ouml;f&amp;ouml;
@@ -8204,7 +8259,7 @@ foo
     }
 
     #[test]
-    fn spec_test_312() {
+    fn spec_test_314() {
         let original = r##"`foo`
 "##;
         let expected = r##"<p><code>foo</code></p>
@@ -8225,7 +8280,7 @@ foo
     }
 
     #[test]
-    fn spec_test_313() {
+    fn spec_test_315() {
         let original = r##"`` foo ` bar  ``
 "##;
         let expected = r##"<p><code>foo ` bar</code></p>
@@ -8246,7 +8301,7 @@ foo
     }
 
     #[test]
-    fn spec_test_314() {
+    fn spec_test_316() {
         let original = r##"` `` `
 "##;
         let expected = r##"<p><code>``</code></p>
@@ -8267,7 +8322,7 @@ foo
     }
 
     #[test]
-    fn spec_test_315() {
+    fn spec_test_317() {
         let original = r##"``
 foo
 ``
@@ -8290,7 +8345,7 @@ foo
     }
 
     #[test]
-    fn spec_test_316() {
+    fn spec_test_318() {
         let original = r##"`foo   bar
   baz`
 "##;
@@ -8312,7 +8367,7 @@ foo
     }
 
     #[test]
-    fn spec_test_317() {
+    fn spec_test_319() {
         let original = r##"`a  b`
 "##;
         let expected = r##"<p><code>a  b</code></p>
@@ -8333,7 +8388,7 @@ foo
     }
 
     #[test]
-    fn spec_test_318() {
+    fn spec_test_320() {
         let original = r##"`foo `` bar`
 "##;
         let expected = r##"<p><code>foo `` bar</code></p>
@@ -8354,7 +8409,7 @@ foo
     }
 
     #[test]
-    fn spec_test_319() {
+    fn spec_test_321() {
         let original = r##"`foo\`bar`
 "##;
         let expected = r##"<p><code>foo\</code>bar`</p>
@@ -8375,7 +8430,7 @@ foo
     }
 
     #[test]
-    fn spec_test_320() {
+    fn spec_test_322() {
         let original = r##"*foo`*`
 "##;
         let expected = r##"<p>*foo<code>*</code></p>
@@ -8396,7 +8451,7 @@ foo
     }
 
     #[test]
-    fn spec_test_321() {
+    fn spec_test_323() {
         let original = r##"[not a `link](/foo`)
 "##;
         let expected = r##"<p>[not a <code>link](/foo</code>)</p>
@@ -8417,7 +8472,7 @@ foo
     }
 
     #[test]
-    fn spec_test_322() {
+    fn spec_test_324() {
         let original = r##"`<a href="`">`
 "##;
         let expected = r##"<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>
@@ -8438,7 +8493,7 @@ foo
     }
 
     #[test]
-    fn spec_test_323() {
+    fn spec_test_325() {
         let original = r##"<a href="`">`
 "##;
         let expected = r##"<p><a href="`">`</p>
@@ -8459,7 +8514,7 @@ foo
     }
 
     #[test]
-    fn spec_test_324() {
+    fn spec_test_326() {
         let original = r##"`<http://foo.bar.`baz>`
 "##;
         let expected = r##"<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>
@@ -8480,7 +8535,7 @@ foo
     }
 
     #[test]
-    fn spec_test_325() {
+    fn spec_test_327() {
         let original = r##"<http://foo.bar.`baz>`
 "##;
         let expected = r##"<p><a href="http://foo.bar.%60baz">http://foo.bar.`baz</a>`</p>
@@ -8501,7 +8556,7 @@ foo
     }
 
     #[test]
-    fn spec_test_326() {
+    fn spec_test_328() {
         let original = r##"```foo``
 "##;
         let expected = r##"<p>```foo``</p>
@@ -8522,7 +8577,7 @@ foo
     }
 
     #[test]
-    fn spec_test_327() {
+    fn spec_test_329() {
         let original = r##"`foo
 "##;
         let expected = r##"<p>`foo</p>
@@ -8543,7 +8598,28 @@ foo
     }
 
     #[test]
-    fn spec_test_328() {
+    fn spec_test_330() {
+        let original = r##"`foo``bar``
+"##;
+        let expected = r##"<p>`foo<code>bar</code></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_331() {
         let original = r##"*foo bar*
 "##;
         let expected = r##"<p><em>foo bar</em></p>
@@ -8564,7 +8640,7 @@ foo
     }
 
     #[test]
-    fn spec_test_329() {
+    fn spec_test_332() {
         let original = r##"a * foo bar*
 "##;
         let expected = r##"<p>a * foo bar*</p>
@@ -8585,7 +8661,7 @@ foo
     }
 
     #[test]
-    fn spec_test_330() {
+    fn spec_test_333() {
         let original = r##"a*"foo"*
 "##;
         let expected = r##"<p>a*&quot;foo&quot;*</p>
@@ -8606,7 +8682,7 @@ foo
     }
 
     #[test]
-    fn spec_test_331() {
+    fn spec_test_334() {
         let original = r##"* a *
 "##;
         let expected = r##"<p>* a *</p>
@@ -8627,7 +8703,7 @@ foo
     }
 
     #[test]
-    fn spec_test_332() {
+    fn spec_test_335() {
         let original = r##"foo*bar*
 "##;
         let expected = r##"<p>foo<em>bar</em></p>
@@ -8648,7 +8724,7 @@ foo
     }
 
     #[test]
-    fn spec_test_333() {
+    fn spec_test_336() {
         let original = r##"5*6*78
 "##;
         let expected = r##"<p>5<em>6</em>78</p>
@@ -8669,7 +8745,7 @@ foo
     }
 
     #[test]
-    fn spec_test_334() {
+    fn spec_test_337() {
         let original = r##"_foo bar_
 "##;
         let expected = r##"<p><em>foo bar</em></p>
@@ -8690,7 +8766,7 @@ foo
     }
 
     #[test]
-    fn spec_test_335() {
+    fn spec_test_338() {
         let original = r##"_ foo bar_
 "##;
         let expected = r##"<p>_ foo bar_</p>
@@ -8711,7 +8787,7 @@ foo
     }
 
     #[test]
-    fn spec_test_336() {
+    fn spec_test_339() {
         let original = r##"a_"foo"_
 "##;
         let expected = r##"<p>a_&quot;foo&quot;_</p>
@@ -8732,7 +8808,7 @@ foo
     }
 
     #[test]
-    fn spec_test_337() {
+    fn spec_test_340() {
         let original = r##"foo_bar_
 "##;
         let expected = r##"<p>foo_bar_</p>
@@ -8753,7 +8829,7 @@ foo
     }
 
     #[test]
-    fn spec_test_338() {
+    fn spec_test_341() {
         let original = r##"5_6_78
 "##;
         let expected = r##"<p>5_6_78</p>
@@ -8774,7 +8850,7 @@ foo
     }
 
     #[test]
-    fn spec_test_339() {
+    fn spec_test_342() {
         let original = r##"пристаням_стремятся_
 "##;
         let expected = r##"<p>пристаням_стремятся_</p>
@@ -8795,7 +8871,7 @@ foo
     }
 
     #[test]
-    fn spec_test_340() {
+    fn spec_test_343() {
         let original = r##"aa_"bb"_cc
 "##;
         let expected = r##"<p>aa_&quot;bb&quot;_cc</p>
@@ -8816,7 +8892,7 @@ foo
     }
 
     #[test]
-    fn spec_test_341() {
+    fn spec_test_344() {
         let original = r##"foo-_(bar)_
 "##;
         let expected = r##"<p>foo-<em>(bar)</em></p>
@@ -8837,7 +8913,7 @@ foo
     }
 
     #[test]
-    fn spec_test_342() {
+    fn spec_test_345() {
         let original = r##"_foo*
 "##;
         let expected = r##"<p>_foo*</p>
@@ -8858,7 +8934,7 @@ foo
     }
 
     #[test]
-    fn spec_test_343() {
+    fn spec_test_346() {
         let original = r##"*foo bar *
 "##;
         let expected = r##"<p>*foo bar *</p>
@@ -8879,7 +8955,7 @@ foo
     }
 
     #[test]
-    fn spec_test_344() {
+    fn spec_test_347() {
         let original = r##"*foo bar
 *
 "##;
@@ -8902,7 +8978,7 @@ foo
     }
 
     #[test]
-    fn spec_test_345() {
+    fn spec_test_348() {
         let original = r##"*(*foo)
 "##;
         let expected = r##"<p>*(*foo)</p>
@@ -8923,7 +8999,7 @@ foo
     }
 
     #[test]
-    fn spec_test_346() {
+    fn spec_test_349() {
         let original = r##"*(*foo*)*
 "##;
         let expected = r##"<p><em>(<em>foo</em>)</em></p>
@@ -8944,7 +9020,7 @@ foo
     }
 
     #[test]
-    fn spec_test_347() {
+    fn spec_test_350() {
         let original = r##"*foo*bar
 "##;
         let expected = r##"<p><em>foo</em>bar</p>
@@ -8965,7 +9041,7 @@ foo
     }
 
     #[test]
-    fn spec_test_348() {
+    fn spec_test_351() {
         let original = r##"_foo bar _
 "##;
         let expected = r##"<p>_foo bar _</p>
@@ -8986,7 +9062,7 @@ foo
     }
 
     #[test]
-    fn spec_test_349() {
+    fn spec_test_352() {
         let original = r##"_(_foo)
 "##;
         let expected = r##"<p>_(_foo)</p>
@@ -9007,7 +9083,7 @@ foo
     }
 
     #[test]
-    fn spec_test_350() {
+    fn spec_test_353() {
         let original = r##"_(_foo_)_
 "##;
         let expected = r##"<p><em>(<em>foo</em>)</em></p>
@@ -9028,7 +9104,7 @@ foo
     }
 
     #[test]
-    fn spec_test_351() {
+    fn spec_test_354() {
         let original = r##"_foo_bar
 "##;
         let expected = r##"<p>_foo_bar</p>
@@ -9049,7 +9125,7 @@ foo
     }
 
     #[test]
-    fn spec_test_352() {
+    fn spec_test_355() {
         let original = r##"_пристаням_стремятся
 "##;
         let expected = r##"<p>_пристаням_стремятся</p>
@@ -9070,7 +9146,7 @@ foo
     }
 
     #[test]
-    fn spec_test_353() {
+    fn spec_test_356() {
         let original = r##"_foo_bar_baz_
 "##;
         let expected = r##"<p><em>foo_bar_baz</em></p>
@@ -9091,7 +9167,7 @@ foo
     }
 
     #[test]
-    fn spec_test_354() {
+    fn spec_test_357() {
         let original = r##"_(bar)_.
 "##;
         let expected = r##"<p><em>(bar)</em>.</p>
@@ -9112,7 +9188,7 @@ foo
     }
 
     #[test]
-    fn spec_test_355() {
+    fn spec_test_358() {
         let original = r##"**foo bar**
 "##;
         let expected = r##"<p><strong>foo bar</strong></p>
@@ -9133,7 +9209,7 @@ foo
     }
 
     #[test]
-    fn spec_test_356() {
+    fn spec_test_359() {
         let original = r##"** foo bar**
 "##;
         let expected = r##"<p>** foo bar**</p>
@@ -9154,7 +9230,7 @@ foo
     }
 
     #[test]
-    fn spec_test_357() {
+    fn spec_test_360() {
         let original = r##"a**"foo"**
 "##;
         let expected = r##"<p>a**&quot;foo&quot;**</p>
@@ -9175,7 +9251,7 @@ foo
     }
 
     #[test]
-    fn spec_test_358() {
+    fn spec_test_361() {
         let original = r##"foo**bar**
 "##;
         let expected = r##"<p>foo<strong>bar</strong></p>
@@ -9196,7 +9272,7 @@ foo
     }
 
     #[test]
-    fn spec_test_359() {
+    fn spec_test_362() {
         let original = r##"__foo bar__
 "##;
         let expected = r##"<p><strong>foo bar</strong></p>
@@ -9217,7 +9293,7 @@ foo
     }
 
     #[test]
-    fn spec_test_360() {
+    fn spec_test_363() {
         let original = r##"__ foo bar__
 "##;
         let expected = r##"<p>__ foo bar__</p>
@@ -9238,7 +9314,7 @@ foo
     }
 
     #[test]
-    fn spec_test_361() {
+    fn spec_test_364() {
         let original = r##"__
 foo bar__
 "##;
@@ -9261,7 +9337,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_362() {
+    fn spec_test_365() {
         let original = r##"a__"foo"__
 "##;
         let expected = r##"<p>a__&quot;foo&quot;__</p>
@@ -9282,7 +9358,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_363() {
+    fn spec_test_366() {
         let original = r##"foo__bar__
 "##;
         let expected = r##"<p>foo__bar__</p>
@@ -9303,7 +9379,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_364() {
+    fn spec_test_367() {
         let original = r##"5__6__78
 "##;
         let expected = r##"<p>5__6__78</p>
@@ -9324,7 +9400,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_365() {
+    fn spec_test_368() {
         let original = r##"пристаням__стремятся__
 "##;
         let expected = r##"<p>пристаням__стремятся__</p>
@@ -9345,7 +9421,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_366() {
+    fn spec_test_369() {
         let original = r##"__foo, __bar__, baz__
 "##;
         let expected = r##"<p><strong>foo, <strong>bar</strong>, baz</strong></p>
@@ -9366,7 +9442,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_367() {
+    fn spec_test_370() {
         let original = r##"foo-__(bar)__
 "##;
         let expected = r##"<p>foo-<strong>(bar)</strong></p>
@@ -9387,7 +9463,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_368() {
+    fn spec_test_371() {
         let original = r##"**foo bar **
 "##;
         let expected = r##"<p>**foo bar **</p>
@@ -9408,7 +9484,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_369() {
+    fn spec_test_372() {
         let original = r##"**(**foo)
 "##;
         let expected = r##"<p>**(**foo)</p>
@@ -9429,7 +9505,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_370() {
+    fn spec_test_373() {
         let original = r##"*(**foo**)*
 "##;
         let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
@@ -9450,7 +9526,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_371() {
+    fn spec_test_374() {
         let original = r##"**Gomphocarpus (*Gomphocarpus physocarpus*, syn.
 *Asclepias physocarpa*)**
 "##;
@@ -9473,7 +9549,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_372() {
+    fn spec_test_375() {
         let original = r##"**foo "*bar*" foo**
 "##;
         let expected = r##"<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>
@@ -9494,7 +9570,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_373() {
+    fn spec_test_376() {
         let original = r##"**foo**bar
 "##;
         let expected = r##"<p><strong>foo</strong>bar</p>
@@ -9515,7 +9591,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_374() {
+    fn spec_test_377() {
         let original = r##"__foo bar __
 "##;
         let expected = r##"<p>__foo bar __</p>
@@ -9536,7 +9612,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_375() {
+    fn spec_test_378() {
         let original = r##"__(__foo)
 "##;
         let expected = r##"<p>__(__foo)</p>
@@ -9557,7 +9633,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_376() {
+    fn spec_test_379() {
         let original = r##"_(__foo__)_
 "##;
         let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
@@ -9578,7 +9654,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_377() {
+    fn spec_test_380() {
         let original = r##"__foo__bar
 "##;
         let expected = r##"<p>__foo__bar</p>
@@ -9599,7 +9675,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_378() {
+    fn spec_test_381() {
         let original = r##"__пристаням__стремятся
 "##;
         let expected = r##"<p>__пристаням__стремятся</p>
@@ -9620,7 +9696,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_379() {
+    fn spec_test_382() {
         let original = r##"__foo__bar__baz__
 "##;
         let expected = r##"<p><strong>foo__bar__baz</strong></p>
@@ -9641,7 +9717,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_380() {
+    fn spec_test_383() {
         let original = r##"__(bar)__.
 "##;
         let expected = r##"<p><strong>(bar)</strong>.</p>
@@ -9662,7 +9738,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_381() {
+    fn spec_test_384() {
         let original = r##"*foo [bar](/url)*
 "##;
         let expected = r##"<p><em>foo <a href="/url">bar</a></em></p>
@@ -9683,7 +9759,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_382() {
+    fn spec_test_385() {
         let original = r##"*foo
 bar*
 "##;
@@ -9706,7 +9782,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_383() {
+    fn spec_test_386() {
         let original = r##"_foo __bar__ baz_
 "##;
         let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
@@ -9727,7 +9803,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_384() {
+    fn spec_test_387() {
         let original = r##"_foo _bar_ baz_
 "##;
         let expected = r##"<p><em>foo <em>bar</em> baz</em></p>
@@ -9748,7 +9824,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_385() {
+    fn spec_test_388() {
         let original = r##"__foo_ bar_
 "##;
         let expected = r##"<p><em><em>foo</em> bar</em></p>
@@ -9769,7 +9845,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_386() {
+    fn spec_test_389() {
         let original = r##"*foo *bar**
 "##;
         let expected = r##"<p><em>foo <em>bar</em></em></p>
@@ -9790,7 +9866,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_387() {
+    fn spec_test_390() {
         let original = r##"*foo **bar** baz*
 "##;
         let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
@@ -9811,7 +9887,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_388() {
+    fn spec_test_391() {
         let original = r##"*foo**bar**baz*
 "##;
         let expected = r##"<p><em>foo<strong>bar</strong>baz</em></p>
@@ -9832,7 +9908,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_389() {
+    fn spec_test_392() {
         let original = r##"***foo** bar*
 "##;
         let expected = r##"<p><em><strong>foo</strong> bar</em></p>
@@ -9853,7 +9929,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_390() {
+    fn spec_test_393() {
         let original = r##"*foo **bar***
 "##;
         let expected = r##"<p><em>foo <strong>bar</strong></em></p>
@@ -9874,7 +9950,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_391() {
+    fn spec_test_394() {
         let original = r##"*foo**bar***
 "##;
         let expected = r##"<p><em>foo<strong>bar</strong></em></p>
@@ -9895,7 +9971,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_392() {
+    fn spec_test_395() {
         let original = r##"*foo **bar *baz* bim** bop*
 "##;
         let expected = r##"<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
@@ -9916,7 +9992,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_393() {
+    fn spec_test_396() {
         let original = r##"*foo [*bar*](/url)*
 "##;
         let expected = r##"<p><em>foo <a href="/url"><em>bar</em></a></em></p>
@@ -9937,7 +10013,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_394() {
+    fn spec_test_397() {
         let original = r##"** is not an empty emphasis
 "##;
         let expected = r##"<p>** is not an empty emphasis</p>
@@ -9958,7 +10034,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_395() {
+    fn spec_test_398() {
         let original = r##"**** is not an empty strong emphasis
 "##;
         let expected = r##"<p>**** is not an empty strong emphasis</p>
@@ -9979,7 +10055,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_396() {
+    fn spec_test_399() {
         let original = r##"**foo [bar](/url)**
 "##;
         let expected = r##"<p><strong>foo <a href="/url">bar</a></strong></p>
@@ -10000,7 +10076,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_397() {
+    fn spec_test_400() {
         let original = r##"**foo
 bar**
 "##;
@@ -10023,7 +10099,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_398() {
+    fn spec_test_401() {
         let original = r##"__foo _bar_ baz__
 "##;
         let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
@@ -10044,7 +10120,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_399() {
+    fn spec_test_402() {
         let original = r##"__foo __bar__ baz__
 "##;
         let expected = r##"<p><strong>foo <strong>bar</strong> baz</strong></p>
@@ -10065,7 +10141,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_400() {
+    fn spec_test_403() {
         let original = r##"____foo__ bar__
 "##;
         let expected = r##"<p><strong><strong>foo</strong> bar</strong></p>
@@ -10086,7 +10162,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_401() {
+    fn spec_test_404() {
         let original = r##"**foo **bar****
 "##;
         let expected = r##"<p><strong>foo <strong>bar</strong></strong></p>
@@ -10107,7 +10183,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_402() {
+    fn spec_test_405() {
         let original = r##"**foo *bar* baz**
 "##;
         let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
@@ -10128,7 +10204,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_403() {
+    fn spec_test_406() {
         let original = r##"**foo*bar*baz**
 "##;
         let expected = r##"<p><strong>foo<em>bar</em>baz</strong></p>
@@ -10149,7 +10225,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_404() {
+    fn spec_test_407() {
         let original = r##"***foo* bar**
 "##;
         let expected = r##"<p><strong><em>foo</em> bar</strong></p>
@@ -10170,7 +10246,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_405() {
+    fn spec_test_408() {
         let original = r##"**foo *bar***
 "##;
         let expected = r##"<p><strong>foo <em>bar</em></strong></p>
@@ -10191,7 +10267,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_406() {
+    fn spec_test_409() {
         let original = r##"**foo *bar **baz**
 bim* bop**
 "##;
@@ -10214,7 +10290,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_407() {
+    fn spec_test_410() {
         let original = r##"**foo [*bar*](/url)**
 "##;
         let expected = r##"<p><strong>foo <a href="/url"><em>bar</em></a></strong></p>
@@ -10235,7 +10311,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_408() {
+    fn spec_test_411() {
         let original = r##"__ is not an empty emphasis
 "##;
         let expected = r##"<p>__ is not an empty emphasis</p>
@@ -10256,7 +10332,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_409() {
+    fn spec_test_412() {
         let original = r##"____ is not an empty strong emphasis
 "##;
         let expected = r##"<p>____ is not an empty strong emphasis</p>
@@ -10277,7 +10353,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_410() {
+    fn spec_test_413() {
         let original = r##"foo ***
 "##;
         let expected = r##"<p>foo ***</p>
@@ -10298,7 +10374,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_411() {
+    fn spec_test_414() {
         let original = r##"foo *\**
 "##;
         let expected = r##"<p>foo <em>*</em></p>
@@ -10319,7 +10395,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_412() {
+    fn spec_test_415() {
         let original = r##"foo *_*
 "##;
         let expected = r##"<p>foo <em>_</em></p>
@@ -10340,7 +10416,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_413() {
+    fn spec_test_416() {
         let original = r##"foo *****
 "##;
         let expected = r##"<p>foo *****</p>
@@ -10361,7 +10437,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_414() {
+    fn spec_test_417() {
         let original = r##"foo **\***
 "##;
         let expected = r##"<p>foo <strong>*</strong></p>
@@ -10382,7 +10458,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_415() {
+    fn spec_test_418() {
         let original = r##"foo **_**
 "##;
         let expected = r##"<p>foo <strong>_</strong></p>
@@ -10403,7 +10479,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_416() {
+    fn spec_test_419() {
         let original = r##"**foo*
 "##;
         let expected = r##"<p>*<em>foo</em></p>
@@ -10424,7 +10500,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_417() {
+    fn spec_test_420() {
         let original = r##"*foo**
 "##;
         let expected = r##"<p><em>foo</em>*</p>
@@ -10445,7 +10521,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_418() {
+    fn spec_test_421() {
         let original = r##"***foo**
 "##;
         let expected = r##"<p>*<strong>foo</strong></p>
@@ -10466,7 +10542,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_419() {
+    fn spec_test_422() {
         let original = r##"****foo*
 "##;
         let expected = r##"<p>***<em>foo</em></p>
@@ -10487,7 +10563,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_420() {
+    fn spec_test_423() {
         let original = r##"**foo***
 "##;
         let expected = r##"<p><strong>foo</strong>*</p>
@@ -10508,7 +10584,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_421() {
+    fn spec_test_424() {
         let original = r##"*foo****
 "##;
         let expected = r##"<p><em>foo</em>***</p>
@@ -10529,7 +10605,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_422() {
+    fn spec_test_425() {
         let original = r##"foo ___
 "##;
         let expected = r##"<p>foo ___</p>
@@ -10550,7 +10626,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_423() {
+    fn spec_test_426() {
         let original = r##"foo _\__
 "##;
         let expected = r##"<p>foo <em>_</em></p>
@@ -10571,7 +10647,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_424() {
+    fn spec_test_427() {
         let original = r##"foo _*_
 "##;
         let expected = r##"<p>foo <em>*</em></p>
@@ -10592,7 +10668,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_425() {
+    fn spec_test_428() {
         let original = r##"foo _____
 "##;
         let expected = r##"<p>foo _____</p>
@@ -10613,7 +10689,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_426() {
+    fn spec_test_429() {
         let original = r##"foo __\___
 "##;
         let expected = r##"<p>foo <strong>_</strong></p>
@@ -10634,7 +10710,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_427() {
+    fn spec_test_430() {
         let original = r##"foo __*__
 "##;
         let expected = r##"<p>foo <strong>*</strong></p>
@@ -10655,7 +10731,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_428() {
+    fn spec_test_431() {
         let original = r##"__foo_
 "##;
         let expected = r##"<p>_<em>foo</em></p>
@@ -10676,7 +10752,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_429() {
+    fn spec_test_432() {
         let original = r##"_foo__
 "##;
         let expected = r##"<p><em>foo</em>_</p>
@@ -10697,7 +10773,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_430() {
+    fn spec_test_433() {
         let original = r##"___foo__
 "##;
         let expected = r##"<p>_<strong>foo</strong></p>
@@ -10718,7 +10794,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_431() {
+    fn spec_test_434() {
         let original = r##"____foo_
 "##;
         let expected = r##"<p>___<em>foo</em></p>
@@ -10739,7 +10815,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_432() {
+    fn spec_test_435() {
         let original = r##"__foo___
 "##;
         let expected = r##"<p><strong>foo</strong>_</p>
@@ -10760,7 +10836,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_433() {
+    fn spec_test_436() {
         let original = r##"_foo____
 "##;
         let expected = r##"<p><em>foo</em>___</p>
@@ -10781,7 +10857,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_434() {
+    fn spec_test_437() {
         let original = r##"**foo**
 "##;
         let expected = r##"<p><strong>foo</strong></p>
@@ -10802,7 +10878,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_435() {
+    fn spec_test_438() {
         let original = r##"*_foo_*
 "##;
         let expected = r##"<p><em><em>foo</em></em></p>
@@ -10823,7 +10899,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_436() {
+    fn spec_test_439() {
         let original = r##"__foo__
 "##;
         let expected = r##"<p><strong>foo</strong></p>
@@ -10844,7 +10920,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_437() {
+    fn spec_test_440() {
         let original = r##"_*foo*_
 "##;
         let expected = r##"<p><em><em>foo</em></em></p>
@@ -10865,7 +10941,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_438() {
+    fn spec_test_441() {
         let original = r##"****foo****
 "##;
         let expected = r##"<p><strong><strong>foo</strong></strong></p>
@@ -10886,7 +10962,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_439() {
+    fn spec_test_442() {
         let original = r##"____foo____
 "##;
         let expected = r##"<p><strong><strong>foo</strong></strong></p>
@@ -10907,7 +10983,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_440() {
+    fn spec_test_443() {
         let original = r##"******foo******
 "##;
         let expected = r##"<p><strong><strong><strong>foo</strong></strong></strong></p>
@@ -10928,10 +11004,10 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_441() {
+    fn spec_test_444() {
         let original = r##"***foo***
 "##;
-        let expected = r##"<p><strong><em>foo</em></strong></p>
+        let expected = r##"<p><em><strong>foo</strong></em></p>
 "##;
 
         use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
@@ -10949,10 +11025,10 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_442() {
+    fn spec_test_445() {
         let original = r##"_____foo_____
 "##;
-        let expected = r##"<p><strong><strong><em>foo</em></strong></strong></p>
+        let expected = r##"<p><em><strong><strong>foo</strong></strong></em></p>
 "##;
 
         use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
@@ -10970,7 +11046,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_443() {
+    fn spec_test_446() {
         let original = r##"*foo _bar* baz_
 "##;
         let expected = r##"<p><em>foo _bar</em> baz_</p>
@@ -10991,7 +11067,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_444() {
+    fn spec_test_447() {
         let original = r##"*foo __bar *baz bim__ bam*
 "##;
         let expected = r##"<p><em>foo <strong>bar *baz bim</strong> bam</em></p>
@@ -11012,7 +11088,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_445() {
+    fn spec_test_448() {
         let original = r##"**foo **bar baz**
 "##;
         let expected = r##"<p>**foo <strong>bar baz</strong></p>
@@ -11033,7 +11109,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_446() {
+    fn spec_test_449() {
         let original = r##"*foo *bar baz*
 "##;
         let expected = r##"<p>*foo <em>bar baz</em></p>
@@ -11054,7 +11130,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_447() {
+    fn spec_test_450() {
         let original = r##"*[bar*](/url)
 "##;
         let expected = r##"<p>*<a href="/url">bar*</a></p>
@@ -11075,7 +11151,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_448() {
+    fn spec_test_451() {
         let original = r##"_foo [bar_](/url)
 "##;
         let expected = r##"<p>_foo <a href="/url">bar_</a></p>
@@ -11096,7 +11172,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_449() {
+    fn spec_test_452() {
         let original = r##"*<img src="foo" title="*"/>
 "##;
         let expected = r##"<p>*<img src="foo" title="*"/></p>
@@ -11117,7 +11193,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_450() {
+    fn spec_test_453() {
         let original = r##"**<a href="**">
 "##;
         let expected = r##"<p>**<a href="**"></p>
@@ -11138,7 +11214,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_451() {
+    fn spec_test_454() {
         let original = r##"__<a href="__">
 "##;
         let expected = r##"<p>__<a href="__"></p>
@@ -11159,7 +11235,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_452() {
+    fn spec_test_455() {
         let original = r##"*a `*`*
 "##;
         let expected = r##"<p><em>a <code>*</code></em></p>
@@ -11180,7 +11256,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_453() {
+    fn spec_test_456() {
         let original = r##"_a `_`_
 "##;
         let expected = r##"<p><em>a <code>_</code></em></p>
@@ -11201,7 +11277,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_454() {
+    fn spec_test_457() {
         let original = r##"**a<http://foo.bar/?q=**>
 "##;
         let expected = r##"<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
@@ -11222,7 +11298,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_455() {
+    fn spec_test_458() {
         let original = r##"__a<http://foo.bar/?q=__>
 "##;
         let expected = r##"<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
@@ -11243,7 +11319,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_456() {
+    fn spec_test_459() {
         let original = r##"[link](/uri "title")
 "##;
         let expected = r##"<p><a href="/uri" title="title">link</a></p>
@@ -11264,7 +11340,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_457() {
+    fn spec_test_460() {
         let original = r##"[link](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link</a></p>
@@ -11285,7 +11361,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_458() {
+    fn spec_test_461() {
         let original = r##"[link]()
 "##;
         let expected = r##"<p><a href="">link</a></p>
@@ -11306,7 +11382,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_459() {
+    fn spec_test_462() {
         let original = r##"[link](<>)
 "##;
         let expected = r##"<p><a href="">link</a></p>
@@ -11327,7 +11403,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_460() {
+    fn spec_test_463() {
         let original = r##"[link](/my uri)
 "##;
         let expected = r##"<p>[link](/my uri)</p>
@@ -11348,7 +11424,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_461() {
+    fn spec_test_464() {
         let original = r##"[link](</my uri>)
 "##;
         let expected = r##"<p>[link](&lt;/my uri&gt;)</p>
@@ -11369,7 +11445,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_462() {
+    fn spec_test_465() {
         let original = r##"[link](foo
 bar)
 "##;
@@ -11392,7 +11468,7 @@ bar)</p>
     }
 
     #[test]
-    fn spec_test_463() {
+    fn spec_test_466() {
         let original = r##"[link](<foo
 bar>)
 "##;
@@ -11415,7 +11491,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_464() {
+    fn spec_test_467() {
         let original = r##"[link](\(foo\))
 "##;
         let expected = r##"<p><a href="(foo)">link</a></p>
@@ -11436,71 +11512,8 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_465() {
-        let original = r##"[link]((foo)and(bar))
-"##;
-        let expected = r##"<p><a href="(foo)and(bar)">link</a></p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
-    fn spec_test_466() {
-        let original = r##"[link](foo(and(bar)))
-"##;
-        let expected = r##"<p>[link](foo(and(bar)))</p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
-    fn spec_test_467() {
-        let original = r##"[link](foo(and\(bar\)))
-"##;
-        let expected = r##"<p><a href="foo(and(bar))">link</a></p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
     fn spec_test_468() {
-        let original = r##"[link](<foo(and(bar))>)
+        let original = r##"[link](foo(and(bar)))
 "##;
         let expected = r##"<p><a href="foo(and(bar))">link</a></p>
 "##;
@@ -11521,6 +11534,48 @@ bar>)</p>
 
     #[test]
     fn spec_test_469() {
+        let original = r##"[link](foo\(and\(bar\))
+"##;
+        let expected = r##"<p><a href="foo(and(bar)">link</a></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_470() {
+        let original = r##"[link](<foo(and(bar)>)
+"##;
+        let expected = r##"<p><a href="foo(and(bar)">link</a></p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_471() {
         let original = r##"[link](foo\)\:)
 "##;
         let expected = r##"<p><a href="foo):">link</a></p>
@@ -11541,7 +11596,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_470() {
+    fn spec_test_472() {
         let original = r##"[link](#fragment)
 
 [link](http://example.com#fragment)
@@ -11568,7 +11623,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_471() {
+    fn spec_test_473() {
         let original = r##"[link](foo\bar)
 "##;
         let expected = r##"<p><a href="foo%5Cbar">link</a></p>
@@ -11589,7 +11644,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_472() {
+    fn spec_test_474() {
         let original = r##"[link](foo%20b&auml;)
 "##;
         let expected = r##"<p><a href="foo%20b%C3%A4">link</a></p>
@@ -11610,7 +11665,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_473() {
+    fn spec_test_475() {
         let original = r##"[link]("title")
 "##;
         let expected = r##"<p><a href="%22title%22">link</a></p>
@@ -11631,7 +11686,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_474() {
+    fn spec_test_476() {
         let original = r##"[link](/url "title")
 [link](/url 'title')
 [link](/url (title))
@@ -11656,7 +11711,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_475() {
+    fn spec_test_477() {
         let original = r##"[link](/url "title \"&quot;")
 "##;
         let expected = r##"<p><a href="/url" title="title &quot;&quot;">link</a></p>
@@ -11677,7 +11732,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_476() {
+    fn spec_test_478() {
         let original = r##"[link](/url "title")
 "##;
         let expected = r##"<p><a href="/url%C2%A0%22title%22">link</a></p>
@@ -11698,7 +11753,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_477() {
+    fn spec_test_479() {
         let original = r##"[link](/url "title "and" title")
 "##;
         let expected = r##"<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>
@@ -11719,7 +11774,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_478() {
+    fn spec_test_480() {
         let original = r##"[link](/url 'title "and" title')
 "##;
         let expected = r##"<p><a href="/url" title="title &quot;and&quot; title">link</a></p>
@@ -11740,7 +11795,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_479() {
+    fn spec_test_481() {
         let original = r##"[link](   /uri
   "title"  )
 "##;
@@ -11762,7 +11817,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_480() {
+    fn spec_test_482() {
         let original = r##"[link] (/uri)
 "##;
         let expected = r##"<p>[link] (/uri)</p>
@@ -11783,7 +11838,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_481() {
+    fn spec_test_483() {
         let original = r##"[link [foo [bar]]](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
@@ -11804,7 +11859,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_482() {
+    fn spec_test_484() {
         let original = r##"[link] bar](/uri)
 "##;
         let expected = r##"<p>[link] bar](/uri)</p>
@@ -11825,7 +11880,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_483() {
+    fn spec_test_485() {
         let original = r##"[link [bar](/uri)
 "##;
         let expected = r##"<p>[link <a href="/uri">bar</a></p>
@@ -11846,7 +11901,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_484() {
+    fn spec_test_486() {
         let original = r##"[link \[bar](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link [bar</a></p>
@@ -11867,7 +11922,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_485() {
+    fn spec_test_487() {
         let original = r##"[link *foo **bar** `#`*](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
@@ -11888,7 +11943,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_486() {
+    fn spec_test_488() {
         let original = r##"[![moon](moon.jpg)](/uri)
 "##;
         let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
@@ -11909,7 +11964,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_487() {
+    fn spec_test_489() {
         let original = r##"[foo [bar](/uri)](/uri)
 "##;
         let expected = r##"<p>[foo <a href="/uri">bar</a>](/uri)</p>
@@ -11930,7 +11985,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_488() {
+    fn spec_test_490() {
         let original = r##"[foo *[bar [baz](/uri)](/uri)*](/uri)
 "##;
         let expected = r##"<p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
@@ -11951,7 +12006,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_489() {
+    fn spec_test_491() {
         let original = r##"![[[foo](uri1)](uri2)](uri3)
 "##;
         let expected = r##"<p><img src="uri3" alt="[foo](uri2)" /></p>
@@ -11972,7 +12027,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_490() {
+    fn spec_test_492() {
         let original = r##"*[foo*](/uri)
 "##;
         let expected = r##"<p>*<a href="/uri">foo*</a></p>
@@ -11993,7 +12048,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_491() {
+    fn spec_test_493() {
         let original = r##"[foo *bar](baz*)
 "##;
         let expected = r##"<p><a href="baz*">foo *bar</a></p>
@@ -12014,7 +12069,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_492() {
+    fn spec_test_494() {
         let original = r##"*foo [bar* baz]
 "##;
         let expected = r##"<p><em>foo [bar</em> baz]</p>
@@ -12035,7 +12090,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_493() {
+    fn spec_test_495() {
         let original = r##"[foo <bar attr="](baz)">
 "##;
         let expected = r##"<p>[foo <bar attr="](baz)"></p>
@@ -12056,7 +12111,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_494() {
+    fn spec_test_496() {
         let original = r##"[foo`](/uri)`
 "##;
         let expected = r##"<p>[foo<code>](/uri)</code></p>
@@ -12077,7 +12132,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_495() {
+    fn spec_test_497() {
         let original = r##"[foo<http://example.com/?search=](uri)>
 "##;
         let expected = r##"<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
@@ -12098,7 +12153,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_496() {
+    fn spec_test_498() {
         let original = r##"[foo][bar]
 
 [bar]: /url "title"
@@ -12121,7 +12176,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_497() {
+    fn spec_test_499() {
         let original = r##"[link [foo [bar]]][ref]
 
 [ref]: /uri
@@ -12144,7 +12199,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_498() {
+    fn spec_test_500() {
         let original = r##"[link \[bar][ref]
 
 [ref]: /uri
@@ -12167,7 +12222,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_499() {
+    fn spec_test_501() {
         let original = r##"[link *foo **bar** `#`*][ref]
 
 [ref]: /uri
@@ -12190,7 +12245,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_500() {
+    fn spec_test_502() {
         let original = r##"[![moon](moon.jpg)][ref]
 
 [ref]: /uri
@@ -12213,7 +12268,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_501() {
+    fn spec_test_503() {
         let original = r##"[foo [bar](/uri)][ref]
 
 [ref]: /uri
@@ -12236,7 +12291,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_502() {
+    fn spec_test_504() {
         let original = r##"[foo *bar [baz][ref]*][ref]
 
 [ref]: /uri
@@ -12259,7 +12314,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_503() {
+    fn spec_test_505() {
         let original = r##"*[foo*][ref]
 
 [ref]: /uri
@@ -12282,7 +12337,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_504() {
+    fn spec_test_506() {
         let original = r##"[foo *bar][ref]
 
 [ref]: /uri
@@ -12305,7 +12360,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_505() {
+    fn spec_test_507() {
         let original = r##"[foo <bar attr="][ref]">
 
 [ref]: /uri
@@ -12328,7 +12383,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_506() {
+    fn spec_test_508() {
         let original = r##"[foo`][ref]`
 
 [ref]: /uri
@@ -12351,7 +12406,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_507() {
+    fn spec_test_509() {
         let original = r##"[foo<http://example.com/?search=][ref]>
 
 [ref]: /uri
@@ -12374,7 +12429,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_508() {
+    fn spec_test_510() {
         let original = r##"[foo][BaR]
 
 [bar]: /url "title"
@@ -12397,7 +12452,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_509() {
+    fn spec_test_511() {
         let original = r##"[Толпой][Толпой] is a Russian word.
 
 [ТОЛПОЙ]: /url
@@ -12420,7 +12475,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_510() {
+    fn spec_test_512() {
         let original = r##"[Foo
   bar]: /url
 
@@ -12444,7 +12499,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_511() {
+    fn spec_test_513() {
         let original = r##"[foo] [bar]
 
 [bar]: /url "title"
@@ -12467,7 +12522,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_512() {
+    fn spec_test_514() {
         let original = r##"[foo]
 [bar]
 
@@ -12492,7 +12547,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_513() {
+    fn spec_test_515() {
         let original = r##"[foo]: /url1
 
 [foo]: /url2
@@ -12517,7 +12572,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_514() {
+    fn spec_test_516() {
         let original = r##"[bar][foo\!]
 
 [foo!]: /url
@@ -12540,7 +12595,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_515() {
+    fn spec_test_517() {
         let original = r##"[foo][ref[]
 
 [ref[]: /uri
@@ -12564,7 +12619,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_516() {
+    fn spec_test_518() {
         let original = r##"[foo][ref[bar]]
 
 [ref[bar]]: /uri
@@ -12588,7 +12643,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_517() {
+    fn spec_test_519() {
         let original = r##"[[[foo]]]
 
 [[[foo]]]: /url
@@ -12612,7 +12667,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_518() {
+    fn spec_test_520() {
         let original = r##"[foo][ref\[]
 
 [ref\[]: /uri
@@ -12635,7 +12690,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_519() {
+    fn spec_test_521() {
         let original = r##"[bar\\]: /uri
 
 [bar\\]
@@ -12658,7 +12713,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_520() {
+    fn spec_test_522() {
         let original = r##"[]
 
 []: /uri
@@ -12682,7 +12737,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_521() {
+    fn spec_test_523() {
         let original = r##"[
  ]
 
@@ -12710,7 +12765,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_522() {
+    fn spec_test_524() {
         let original = r##"[foo][]
 
 [foo]: /url "title"
@@ -12733,7 +12788,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_523() {
+    fn spec_test_525() {
         let original = r##"[*foo* bar][]
 
 [*foo* bar]: /url "title"
@@ -12756,7 +12811,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_524() {
+    fn spec_test_526() {
         let original = r##"[Foo][]
 
 [foo]: /url "title"
@@ -12779,7 +12834,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_525() {
+    fn spec_test_527() {
         let original = r##"[foo] 
 []
 
@@ -12804,7 +12859,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_526() {
+    fn spec_test_528() {
         let original = r##"[foo]
 
 [foo]: /url "title"
@@ -12827,7 +12882,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_527() {
+    fn spec_test_529() {
         let original = r##"[*foo* bar]
 
 [*foo* bar]: /url "title"
@@ -12850,7 +12905,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_528() {
+    fn spec_test_530() {
         let original = r##"[[*foo* bar]]
 
 [*foo* bar]: /url "title"
@@ -12873,7 +12928,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_529() {
+    fn spec_test_531() {
         let original = r##"[[bar [foo]
 
 [foo]: /url
@@ -12896,7 +12951,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_530() {
+    fn spec_test_532() {
         let original = r##"[Foo]
 
 [foo]: /url "title"
@@ -12919,7 +12974,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_531() {
+    fn spec_test_533() {
         let original = r##"[foo] bar
 
 [foo]: /url
@@ -12942,7 +12997,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_532() {
+    fn spec_test_534() {
         let original = r##"\[foo]
 
 [foo]: /url "title"
@@ -12965,7 +13020,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_533() {
+    fn spec_test_535() {
         let original = r##"[foo*]: /url
 
 *[foo*]
@@ -12988,7 +13043,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_534() {
+    fn spec_test_536() {
         let original = r##"[foo][bar]
 
 [foo]: /url1
@@ -13012,7 +13067,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_535() {
+    fn spec_test_537() {
         let original = r##"[foo][]
 
 [foo]: /url1
@@ -13035,7 +13090,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_536() {
+    fn spec_test_538() {
         let original = r##"[foo]()
 
 [foo]: /url1
@@ -13058,7 +13113,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_537() {
+    fn spec_test_539() {
         let original = r##"[foo](not a link)
 
 [foo]: /url1
@@ -13081,7 +13136,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_538() {
+    fn spec_test_540() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url
@@ -13104,7 +13159,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_539() {
+    fn spec_test_541() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url1
@@ -13128,7 +13183,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_540() {
+    fn spec_test_542() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url1
@@ -13152,7 +13207,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_541() {
+    fn spec_test_543() {
         let original = r##"![foo](/url "title")
 "##;
         let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
@@ -13173,7 +13228,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_542() {
+    fn spec_test_544() {
         let original = r##"![foo *bar*]
 
 [foo *bar*]: train.jpg "train & tracks"
@@ -13196,7 +13251,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_543() {
+    fn spec_test_545() {
         let original = r##"![foo ![bar](/url)](/url2)
 "##;
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
@@ -13217,7 +13272,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_544() {
+    fn spec_test_546() {
         let original = r##"![foo [bar](/url)](/url2)
 "##;
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
@@ -13238,7 +13293,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_545() {
+    fn spec_test_547() {
         let original = r##"![foo *bar*][]
 
 [foo *bar*]: train.jpg "train & tracks"
@@ -13261,7 +13316,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_546() {
+    fn spec_test_548() {
         let original = r##"![foo *bar*][foobar]
 
 [FOOBAR]: train.jpg "train & tracks"
@@ -13284,7 +13339,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_547() {
+    fn spec_test_549() {
         let original = r##"![foo](train.jpg)
 "##;
         let expected = r##"<p><img src="train.jpg" alt="foo" /></p>
@@ -13305,7 +13360,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_548() {
+    fn spec_test_550() {
         let original = r##"My ![foo bar](/path/to/train.jpg  "title"   )
 "##;
         let expected = r##"<p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
@@ -13326,7 +13381,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_549() {
+    fn spec_test_551() {
         let original = r##"![foo](<url>)
 "##;
         let expected = r##"<p><img src="url" alt="foo" /></p>
@@ -13347,7 +13402,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_550() {
+    fn spec_test_552() {
         let original = r##"![](/url)
 "##;
         let expected = r##"<p><img src="/url" alt="" /></p>
@@ -13368,7 +13423,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_551() {
+    fn spec_test_553() {
         let original = r##"![foo][bar]
 
 [bar]: /url
@@ -13391,7 +13446,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_552() {
+    fn spec_test_554() {
         let original = r##"![foo][bar]
 
 [BAR]: /url
@@ -13414,7 +13469,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_553() {
+    fn spec_test_555() {
         let original = r##"![foo][]
 
 [foo]: /url "title"
@@ -13437,7 +13492,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_554() {
+    fn spec_test_556() {
         let original = r##"![*foo* bar][]
 
 [*foo* bar]: /url "title"
@@ -13460,7 +13515,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_555() {
+    fn spec_test_557() {
         let original = r##"![Foo][]
 
 [foo]: /url "title"
@@ -13483,7 +13538,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_556() {
+    fn spec_test_558() {
         let original = r##"![foo] 
 []
 
@@ -13508,7 +13563,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_557() {
+    fn spec_test_559() {
         let original = r##"![foo]
 
 [foo]: /url "title"
@@ -13531,7 +13586,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_558() {
+    fn spec_test_560() {
         let original = r##"![*foo* bar]
 
 [*foo* bar]: /url "title"
@@ -13554,7 +13609,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_559() {
+    fn spec_test_561() {
         let original = r##"![[foo]]
 
 [[foo]]: /url "title"
@@ -13578,7 +13633,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_560() {
+    fn spec_test_562() {
         let original = r##"![Foo]
 
 [foo]: /url "title"
@@ -13601,8 +13656,8 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_561() {
-        let original = r##"\!\[foo]
+    fn spec_test_563() {
+        let original = r##"!\[foo]
 
 [foo]: /url "title"
 "##;
@@ -13624,7 +13679,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_562() {
+    fn spec_test_564() {
         let original = r##"\![foo]
 
 [foo]: /url "title"
@@ -13647,7 +13702,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_563() {
+    fn spec_test_565() {
         let original = r##"<http://foo.bar.baz>
 "##;
         let expected = r##"<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
@@ -13668,7 +13723,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_564() {
+    fn spec_test_566() {
         let original = r##"<http://foo.bar.baz/test?q=hello&id=22&boolean>
 "##;
         let expected = r##"<p><a href="http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
@@ -13689,7 +13744,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_565() {
+    fn spec_test_567() {
         let original = r##"<irc://foo.bar:2233/baz>
 "##;
         let expected = r##"<p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
@@ -13710,7 +13765,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_566() {
+    fn spec_test_568() {
         let original = r##"<MAILTO:FOO@BAR.BAZ>
 "##;
         let expected = r##"<p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
@@ -13731,7 +13786,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_567() {
+    fn spec_test_569() {
         let original = r##"<a+b+c:d>
 "##;
         let expected = r##"<p><a href="a+b+c:d">a+b+c:d</a></p>
@@ -13752,7 +13807,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_568() {
+    fn spec_test_570() {
         let original = r##"<made-up-scheme://foo,bar>
 "##;
         let expected = r##"<p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
@@ -13773,7 +13828,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_569() {
+    fn spec_test_571() {
         let original = r##"<http://../>
 "##;
         let expected = r##"<p><a href="http://../">http://../</a></p>
@@ -13794,7 +13849,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_570() {
+    fn spec_test_572() {
         let original = r##"<localhost:5001/foo>
 "##;
         let expected = r##"<p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
@@ -13815,7 +13870,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_571() {
+    fn spec_test_573() {
         let original = r##"<http://foo.bar/baz bim>
 "##;
         let expected = r##"<p>&lt;http://foo.bar/baz bim&gt;</p>
@@ -13836,7 +13891,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_572() {
+    fn spec_test_574() {
         let original = r##"<http://example.com/\[\>
 "##;
         let expected = r##"<p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
@@ -13857,7 +13912,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_573() {
+    fn spec_test_575() {
         let original = r##"<foo@bar.example.com>
 "##;
         let expected = r##"<p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
@@ -13878,7 +13933,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_574() {
+    fn spec_test_576() {
         let original = r##"<foo+special@Bar.baz-bar0.com>
 "##;
         let expected = r##"<p><a href="mailto:foo+special@Bar.baz-bar0.com">foo+special@Bar.baz-bar0.com</a></p>
@@ -13899,7 +13954,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_575() {
+    fn spec_test_577() {
         let original = r##"<foo\+@bar.example.com>
 "##;
         let expected = r##"<p>&lt;foo+@bar.example.com&gt;</p>
@@ -13920,7 +13975,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_576() {
+    fn spec_test_578() {
         let original = r##"<>
 "##;
         let expected = r##"<p>&lt;&gt;</p>
@@ -13941,7 +13996,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_577() {
+    fn spec_test_579() {
         let original = r##"< http://foo.bar >
 "##;
         let expected = r##"<p>&lt; http://foo.bar &gt;</p>
@@ -13962,7 +14017,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_578() {
+    fn spec_test_580() {
         let original = r##"<m:abc>
 "##;
         let expected = r##"<p>&lt;m:abc&gt;</p>
@@ -13983,7 +14038,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_579() {
+    fn spec_test_581() {
         let original = r##"<foo.bar.baz>
 "##;
         let expected = r##"<p>&lt;foo.bar.baz&gt;</p>
@@ -14004,7 +14059,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_580() {
+    fn spec_test_582() {
         let original = r##"http://example.com
 "##;
         let expected = r##"<p>http://example.com</p>
@@ -14025,7 +14080,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_581() {
+    fn spec_test_583() {
         let original = r##"foo@bar.example.com
 "##;
         let expected = r##"<p>foo@bar.example.com</p>
@@ -14046,7 +14101,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_582() {
+    fn spec_test_584() {
         let original = r##"<a><bab><c2c>
 "##;
         let expected = r##"<p><a><bab><c2c></p>
@@ -14067,7 +14122,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_583() {
+    fn spec_test_585() {
         let original = r##"<a/><b2/>
 "##;
         let expected = r##"<p><a/><b2/></p>
@@ -14088,7 +14143,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_584() {
+    fn spec_test_586() {
         let original = r##"<a  /><b2
 data="foo" >
 "##;
@@ -14111,7 +14166,7 @@ data="foo" ></p>
     }
 
     #[test]
-    fn spec_test_585() {
+    fn spec_test_587() {
         let original = r##"<a foo="bar" bam = 'baz <em>"</em>'
 _boolean zoop:33=zoop:33 />
 "##;
@@ -14134,7 +14189,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_586() {
+    fn spec_test_588() {
         let original = r##"Foo <responsive-image src="foo.jpg" />
 "##;
         let expected = r##"<p>Foo <responsive-image src="foo.jpg" /></p>
@@ -14155,7 +14210,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_587() {
+    fn spec_test_589() {
         let original = r##"<33> <__>
 "##;
         let expected = r##"<p>&lt;33&gt; &lt;__&gt;</p>
@@ -14176,7 +14231,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_588() {
+    fn spec_test_590() {
         let original = r##"<a h*#ref="hi">
 "##;
         let expected = r##"<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>
@@ -14197,7 +14252,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_589() {
+    fn spec_test_591() {
         let original = r##"<a href="hi'> <a href=hi'>
 "##;
         let expected = r##"<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>
@@ -14218,7 +14273,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_590() {
+    fn spec_test_592() {
         let original = r##"< a><
 foo><bar/ >
 "##;
@@ -14241,7 +14296,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_591() {
+    fn spec_test_593() {
         let original = r##"<a href='bar'title=title>
 "##;
         let expected = r##"<p>&lt;a href='bar'title=title&gt;</p>
@@ -14262,7 +14317,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_592() {
+    fn spec_test_594() {
         let original = r##"</a></foo >
 "##;
         let expected = r##"<p></a></foo ></p>
@@ -14283,7 +14338,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_593() {
+    fn spec_test_595() {
         let original = r##"</a href="foo">
 "##;
         let expected = r##"<p>&lt;/a href=&quot;foo&quot;&gt;</p>
@@ -14304,7 +14359,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_594() {
+    fn spec_test_596() {
         let original = r##"foo <!-- this is a
 comment - with hyphen -->
 "##;
@@ -14327,7 +14382,7 @@ comment - with hyphen --></p>
     }
 
     #[test]
-    fn spec_test_595() {
+    fn spec_test_597() {
         let original = r##"foo <!-- not a comment -- two hyphens -->
 "##;
         let expected = r##"<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
@@ -14348,7 +14403,7 @@ comment - with hyphen --></p>
     }
 
     #[test]
-    fn spec_test_596() {
+    fn spec_test_598() {
         let original = r##"foo <!--> foo -->
 
 foo <!-- foo--->
@@ -14372,7 +14427,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_597() {
+    fn spec_test_599() {
         let original = r##"foo <?php echo $a; ?>
 "##;
         let expected = r##"<p>foo <?php echo $a; ?></p>
@@ -14393,7 +14448,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_598() {
+    fn spec_test_600() {
         let original = r##"foo <!ELEMENT br EMPTY>
 "##;
         let expected = r##"<p>foo <!ELEMENT br EMPTY></p>
@@ -14414,7 +14469,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_599() {
+    fn spec_test_601() {
         let original = r##"foo <![CDATA[>&<]]>
 "##;
         let expected = r##"<p>foo <![CDATA[>&<]]></p>
@@ -14435,7 +14490,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_600() {
+    fn spec_test_602() {
         let original = r##"foo <a href="&ouml;">
 "##;
         let expected = r##"<p>foo <a href="&ouml;"></p>
@@ -14456,7 +14511,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_601() {
+    fn spec_test_603() {
         let original = r##"foo <a href="\*">
 "##;
         let expected = r##"<p>foo <a href="\*"></p>
@@ -14477,7 +14532,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_602() {
+    fn spec_test_604() {
         let original = r##"<a href="\"">
 "##;
         let expected = r##"<p>&lt;a href=&quot;&quot;&quot;&gt;</p>
@@ -14498,54 +14553,8 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_603() {
-        let original = r##"foo  
-baz
-"##;
-        let expected = r##"<p>foo<br />
-baz</p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
-    fn spec_test_604() {
-        let original = r##"foo\
-baz
-"##;
-        let expected = r##"<p>foo<br />
-baz</p>
-"##;
-
-        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
-
-        let mut s = String::new();
-
-        let mut opts = Options::empty();
-        opts.insert(OPTION_ENABLE_TABLES);
-        opts.insert(OPTION_ENABLE_FOOTNOTES);
-
-        let p = Parser::new_ext(&original, opts);
-        html::push_html(&mut s, p);
-
-        assert_eq!(expected, s);
-    }
-
-    #[test]
     fn spec_test_605() {
-        let original = r##"foo       
+        let original = r##"foo  
 baz
 "##;
         let expected = r##"<p>foo<br />
@@ -14568,6 +14577,52 @@ baz</p>
 
     #[test]
     fn spec_test_606() {
+        let original = r##"foo\
+baz
+"##;
+        let expected = r##"<p>foo<br />
+baz</p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_607() {
+        let original = r##"foo       
+baz
+"##;
+        let expected = r##"<p>foo<br />
+baz</p>
+"##;
+
+        use pulldown_cmark::{Parser, html, Options, OPTION_ENABLE_TABLES, OPTION_ENABLE_FOOTNOTES};
+
+        let mut s = String::new();
+
+        let mut opts = Options::empty();
+        opts.insert(OPTION_ENABLE_TABLES);
+        opts.insert(OPTION_ENABLE_FOOTNOTES);
+
+        let p = Parser::new_ext(&original, opts);
+        html::push_html(&mut s, p);
+
+        assert_eq!(expected, s);
+    }
+
+    #[test]
+    fn spec_test_608() {
         let original = r##"foo  
      bar
 "##;
@@ -14590,7 +14645,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_607() {
+    fn spec_test_609() {
         let original = r##"foo\
      bar
 "##;
@@ -14613,7 +14668,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_608() {
+    fn spec_test_610() {
         let original = r##"*foo  
 bar*
 "##;
@@ -14636,7 +14691,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_609() {
+    fn spec_test_611() {
         let original = r##"*foo\
 bar*
 "##;
@@ -14659,7 +14714,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_610() {
+    fn spec_test_612() {
         let original = r##"`code  
 span`
 "##;
@@ -14681,7 +14736,7 @@ span`
     }
 
     #[test]
-    fn spec_test_611() {
+    fn spec_test_613() {
         let original = r##"`code\
 span`
 "##;
@@ -14703,7 +14758,7 @@ span`
     }
 
     #[test]
-    fn spec_test_612() {
+    fn spec_test_614() {
         let original = r##"<a href="foo  
 bar">
 "##;
@@ -14726,7 +14781,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_613() {
+    fn spec_test_615() {
         let original = r##"<a href="foo\
 bar">
 "##;
@@ -14749,7 +14804,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_614() {
+    fn spec_test_616() {
         let original = r##"foo\
 "##;
         let expected = r##"<p>foo\</p>
@@ -14770,7 +14825,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_615() {
+    fn spec_test_617() {
         let original = r##"foo  
 "##;
         let expected = r##"<p>foo</p>
@@ -14791,7 +14846,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_616() {
+    fn spec_test_618() {
         let original = r##"### foo\
 "##;
         let expected = r##"<h3>foo\</h3>
@@ -14812,7 +14867,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_617() {
+    fn spec_test_619() {
         let original = r##"### foo  
 "##;
         let expected = r##"<h3>foo</h3>
@@ -14833,7 +14888,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_618() {
+    fn spec_test_620() {
         let original = r##"foo
 baz
 "##;
@@ -14856,7 +14911,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_619() {
+    fn spec_test_621() {
         let original = r##"foo 
  baz
 "##;
@@ -14879,7 +14934,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_620() {
+    fn spec_test_622() {
         let original = r##"hello $.;'there
 "##;
         let expected = r##"<p>hello $.;'there</p>
@@ -14900,7 +14955,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_621() {
+    fn spec_test_623() {
         let original = r##"Foo χρῆν
 "##;
         let expected = r##"<p>Foo χρῆν</p>
@@ -14921,7 +14976,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_622() {
+    fn spec_test_624() {
         let original = r##"Multiple     spaces
 "##;
         let expected = r##"<p>Multiple     spaces</p>

--- a/third_party/CommonMark/spec.txt
+++ b/third_party/CommonMark/spec.txt
@@ -1,8 +1,8 @@
 ---
 title: CommonMark Spec
 author: John MacFarlane
-version: 0.27
-date: '2016-11-18'
+version: 0.28
+date: '2017-08-01'
 license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 
@@ -11,10 +11,12 @@ license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 ## What is Markdown?
 
 Markdown is a plain text format for writing structured documents,
-based on conventions used for indicating formatting in email and
-usenet posts.  It was developed in 2004 by John Gruber, who wrote
-the first Markdown-to-HTML converter in Perl, and it soon became
-ubiquitous.  In the next decade, dozens of implementations were
+based on conventions for indicating formatting in email
+and usenet posts.  It was developed by John Gruber (with
+help from Aaron Swartz) and released in 2004 in the form of a
+[syntax description](http://daringfireball.net/projects/markdown/syntax)
+and a Perl script (`Markdown.pl`) for converting Markdown to
+HTML.  In the next decade, dozens of implementations were
 developed in many languages.  Some extended the original
 Markdown syntax with conventions for footnotes, tables, and
 other document elements.  Some allowed Markdown documents to be
@@ -312,7 +314,7 @@ form feed (`U+000C`), or carriage return (`U+000D`).
 characters].
 
 A [Unicode whitespace character](@) is
-any code point in the Unicode `Zs` class, or a tab (`U+0009`),
+any code point in the Unicode `Zs` general category, or a tab (`U+0009`),
 carriage return (`U+000D`), newline (`U+000A`), or form feed
 (`U+000C`).
 
@@ -331,7 +333,7 @@ is `!`, `"`, `#`, `$`, `%`, `&`, `'`, `(`, `)`,
 
 A [punctuation character](@) is an [ASCII
 punctuation character] or anything in
-the Unicode classes `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
+the general Unicode categories  `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
 
 ## Tabs
 
@@ -402,8 +404,8 @@ as indentation with four spaces would:
 Normally the `>` that begins a block quote may be followed
 optionally by a space, which is not considered part of the
 content.  In the following case `>` is followed by a tab,
-which is treated as if it were expanded into spaces.
-Since one of theses spaces is considered part of the
+which is treated as if it were expanded into three spaces.
+Since one of these spaces is considered part of the
 delimiter, `foo` is considered to be indented six spaces
 inside the block quote context, so we get an indented
 code block starting with two spaces.
@@ -481,7 +483,7 @@ We can think of a document as a sequence of
 quotations, lists, headings, rules, and code blocks.  Some blocks (like
 block quotes and list items) contain other blocks; others (like
 headings and paragraphs) contain [inline](@) content---text,
-links, emphasized text, images, code, and so on.
+links, emphasized text, images, code spans, and so on.
 
 ## Precedence
 
@@ -1643,6 +1645,15 @@ With tildes:
 </code></pre>
 ````````````````````````````````
 
+Fewer than three backticks is not enough:
+
+```````````````````````````````` example
+``
+foo
+``
+.
+<p><code>foo</code></p>
+````````````````````````````````
 
 The closing code fence must use the same character as the opening
 fence:
@@ -2030,6 +2041,37 @@ or [closing tag] (with any [tag name] other than `script`,
 `style`, or `pre`) followed only by [whitespace]
 or the end of the line.\
 **End condition:** line is followed by a [blank line].
+
+HTML blocks continue until they are closed by their appropriate
+[end condition], or the last line of the document or other [container block].
+This means any HTML **within an HTML block** that might otherwise be recognised
+as a start condition will be ignored by the parser and passed through as-is,
+without changing the parser's state.
+
+For instance, `<pre>` within a HTML block started by `<table>` will not affect
+the parser state; as the HTML block was started in by start condition 6, it
+will end at any blank line. This can be surprising:
+
+```````````````````````````````` example
+<table><tr><td>
+<pre>
+**Hello**,
+
+_world_.
+</pre>
+</td></tr></table>
+.
+<table><tr><td>
+<pre>
+**Hello**,
+<p><em>world</em>.
+</pre></p>
+</td></tr></table>
+````````````````````````````````
+
+In this case, the HTML block is terminated by the newline — the `**hello**`
+text remains verbatim — and regular parsing resumes, with a paragraph,
+emphasised `world` and inline and block HTML following.
 
 All types of [HTML blocks] except type 7 may interrupt
 a paragraph.  Blocks of type 7 may not interrupt a paragraph.
@@ -3637,11 +3679,15 @@ The following rules define [list items]:
     If the list item is ordered, then it is also assigned a start
     number, based on the ordered list marker.
 
-    Exceptions: When the first list item in a [list] interrupts
-    a paragraph---that is, when it starts on a line that would
-    otherwise count as [paragraph continuation text]---then (a)
-    the lines *Ls* must not begin with a blank line, and (b) if
-    the list item is ordered, the start number must be 1.
+    Exceptions:
+
+    1. When the first list item in a [list] interrupts
+       a paragraph---that is, when it starts on a line that would
+       otherwise count as [paragraph continuation text]---then (a)
+       the lines *Ls* must not begin with a blank line, and (b) if
+       the list item is ordered, the start number must be 1.
+    2. If any line is a [thematic break][thematic breaks] then
+       that line is not a list item.
 
 For example, let *Ls* be the lines
 
@@ -5796,6 +5842,15 @@ we just have literal backticks:
 <p>`foo</p>
 ````````````````````````````````
 
+The following case also illustrates the need for opening and
+closing backtick strings to be equal in length:
+
+```````````````````````````````` example
+`foo``bar``
+.
+<p>`foo<code>bar</code></p>
+````````````````````````````````
+
 
 ## Emphasis and strong emphasis
 
@@ -5845,19 +5900,20 @@ for efficient parsing strategies that do not backtrack.
 
 First, some definitions.  A [delimiter run](@) is either
 a sequence of one or more `*` characters that is not preceded or
-followed by a `*` character, or a sequence of one or more `_`
-characters that is not preceded or followed by a `_` character.
+followed by a non-backslash-escaped `*` character, or a sequence
+of one or more `_` characters that is not preceded or followed by
+a non-backslash-escaped `_` character.
 
 A [left-flanking delimiter run](@) is
 a [delimiter run] that is (a) not followed by [Unicode whitespace],
-and (b) either not followed by a [punctuation character], or
+and (b) not followed by a [punctuation character], or
 preceded by [Unicode whitespace] or a [punctuation character].
 For purposes of this definition, the beginning and the end of
 the line count as Unicode whitespace.
 
 A [right-flanking delimiter run](@) is
 a [delimiter run] that is (a) not preceded by [Unicode whitespace],
-and (b) either not preceded by a [punctuation character], or
+and (b) not preceded by a [punctuation character], or
 followed by [Unicode whitespace] or a [punctuation character].
 For purposes of this definition, the beginning and the end of
 the line count as Unicode whitespace.
@@ -5936,7 +5992,7 @@ The following rules define emphasis and strong emphasis:
 7.  A double `**` [can close strong emphasis](@)
     iff it is part of a [right-flanking delimiter run].
 
-8.  A double `__` [can close strong emphasis]
+8.  A double `__` [can close strong emphasis] iff
     it is part of a [right-flanking delimiter run]
     and either (a) not part of a [left-flanking delimiter run]
     or (b) part of a [left-flanking delimiter run]
@@ -5976,8 +6032,8 @@ the following principles resolve ambiguity:
     an interpretation `<strong>...</strong>` is always preferred to
     `<em><em>...</em></em>`.
 
-14. An interpretation `<strong><em>...</em></strong>` is always
-    preferred to `<em><strong>..</strong></em>`.
+14. An interpretation `<em><strong>...</strong></em>` is always
+    preferred to `<strong><em>...</em></strong>`.
 
 15. When two potential emphasis or strong emphasis spans overlap,
     so that the second begins before the first ends and ends after
@@ -7000,14 +7056,14 @@ Rule 14:
 ```````````````````````````````` example
 ***foo***
 .
-<p><strong><em>foo</em></strong></p>
+<p><em><strong>foo</strong></em></p>
 ````````````````````````````````
 
 
 ```````````````````````````````` example
 _____foo_____
 .
-<p><strong><strong><em>foo</em></strong></strong></p>
+<p><em><strong><strong>foo</strong></strong></em></p>
 ````````````````````````````````
 
 
@@ -7148,8 +7204,9 @@ A [link destination](@) consists of either
 - a nonempty sequence of characters that does not include
   ASCII space or control characters, and includes parentheses
   only if (a) they are backslash-escaped or (b) they are part of
-  a balanced pair of unescaped parentheses that is not itself
-  inside a balanced pair of unescaped parentheses.
+  a balanced pair of unescaped parentheses.  (Implementations
+  may impose limits on parentheses nesting to avoid performance
+  issues, but at least three levels of nesting should be supported.)
 
 A [link title](@)  consists of either
 
@@ -7255,35 +7312,29 @@ Parentheses inside the link destination may be escaped:
 <p><a href="(foo)">link</a></p>
 ````````````````````````````````
 
-One level of balanced parentheses is allowed without escaping:
-
-```````````````````````````````` example
-[link]((foo)and(bar))
-.
-<p><a href="(foo)and(bar)">link</a></p>
-````````````````````````````````
-
-However, if you have parentheses within parentheses, you need to escape
-or use the `<...>` form:
+Any number of parentheses are allowed without escaping, as long as they are
+balanced:
 
 ```````````````````````````````` example
 [link](foo(and(bar)))
 .
-<p>[link](foo(and(bar)))</p>
+<p><a href="foo(and(bar))">link</a></p>
+````````````````````````````````
+
+However, if you have unbalanced parentheses, you need to escape or use the
+`<...>` form:
+
+```````````````````````````````` example
+[link](foo\(and\(bar\))
+.
+<p><a href="foo(and(bar)">link</a></p>
 ````````````````````````````````
 
 
 ```````````````````````````````` example
-[link](foo(and\(bar\)))
+[link](<foo(and(bar)>)
 .
-<p><a href="foo(and(bar))">link</a></p>
-````````````````````````````````
-
-
-```````````````````````````````` example
-[link](<foo(and(bar))>)
-.
-<p><a href="foo(and(bar))">link</a></p>
+<p><a href="foo(and(bar)">link</a></p>
 ````````````````````````````````
 
 
@@ -7567,13 +7618,16 @@ that [matches] a [link reference definition] elsewhere in the document.
 A [link label](@)  begins with a left bracket (`[`) and ends
 with the first right bracket (`]`) that is not backslash-escaped.
 Between these brackets there must be at least one [non-whitespace character].
-Unescaped square bracket characters are not allowed in
-[link labels].  A link label can have at most 999
-characters inside the square brackets.
+Unescaped square bracket characters are not allowed inside the
+opening and closing square brackets of [link labels].  A link
+label can have at most 999 characters inside the square
+brackets.
 
 One label [matches](@)
 another just in case their normalized forms are equal.  To normalize a
-label, perform the *Unicode case fold* and collapse consecutive internal
+label, strip off the opening and closing brackets,
+perform the *Unicode case fold*, strip leading and trailing
+[whitespace] and collapse consecutive internal
 [whitespace] to a single space.  If there are multiple
 matching reference link definitions, the one that comes first in the
 document is used.  (It is desirable in such cases to emit a warning.)
@@ -8326,11 +8380,11 @@ The link labels are case-insensitive:
 ````````````````````````````````
 
 
-If you just want bracketed text, you can backslash-escape the
-opening `!` and `[`:
+If you just want a literal `!` followed by bracketed text, you can
+backslash-escape the opening `[`:
 
 ```````````````````````````````` example
-\!\[foo]
+!\[foo]
 
 [foo]: /url "title"
 .


### PR DESCRIPTION
Commonmark 0.28 released about a month ago; I auto-generated the spec tests with the new spec.