### PR TITLE
Handle container blocks in new algorithm

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -178,6 +178,7 @@ impl<'a, 'b, I: Iterator<Item=Event<'a>>> Ctx<'b, I> {
                 self.buf.push_str(&*format!("{}", number));
                 self.buf.push_str("</sup>");
             }
+            Tag::HtmlBlock => {}
         }
     }
 
@@ -218,6 +219,7 @@ impl<'a, 'b, I: Iterator<Item=Event<'a>>> Ctx<'b, I> {
             Tag::Link(_, _) => self.buf.push_str("</a>"),
             Tag::Image(_, _) => (), // shouldn't happen, handled in start
             Tag::FootnoteDefinition(_) => self.buf.push_str("</div>\n"),
+            Tag::HtmlBlock => {}
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
             print!(" ");
         }
 
-        let our_html = render_html(&test.input.replace("→", "\t").replace("\n", "\r\n"), opts);
+        let our_html = render_html(&test.input.replace("→", "\t"), opts);
 
         if our_html == test.expected.replace("→", "\t") {
             print!(".");

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn run_spec(spec_text: &str, args: &[String], opts: Options) {
             print!(" ");
         }
 
-        let our_html = render_html(&test.input.replace("→", "\t"), opts);
+        let our_html = render_html(&test.input.replace("→", "\t").replace("\n", "\r\n"), opts);
 
         if our_html == test.expected.replace("→", "\t") {
             print!(".");

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -91,6 +91,7 @@ pub enum Tag<'a> {
     List(Option<usize>),  // TODO: add delim and tight for ast (not needed for html)
     Item,
     FootnoteDefinition(Cow<'a, str>),
+    HtmlBlock,
 
     // tables
     Table(Vec<Alignment>),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -74,6 +74,7 @@ pub struct RawParser<'a> {
     links: HashMap<String, (Cow<'a, str>, Cow<'a, str>)>,
 }
 
+#[allow(dead_code)]
 pub struct ParseInfo<'a> {
     pub loose_lists: HashSet<usize>,
     pub links: HashMap<String, (Cow<'a, str>, Cow<'a, str>)>,
@@ -135,6 +136,7 @@ bitflags! {
 
 const MAX_LINK_NEST: usize = 10;
 
+#[allow(dead_code)]
 impl<'a> RawParser<'a> {
     pub fn new_with_links(text: &'a str, opts: Options,
             links: HashMap<String, (Cow<'a, str>, Cow<'a, str>)>) -> RawParser<'a> {

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -467,7 +467,7 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> Option<usize> {
 
 // Used on a new line, after scan_containers
 // scans to first character after new container markers
-fn parse_new_containers(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
+fn parse_new_containers(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     let begin = ix;
     let leading_bytes = scan_leading_space(s, ix).0;
     loop {
@@ -487,7 +487,7 @@ fn parse_new_containers(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> us
             continue;
         }
 
-        let (listitem_bytes, listitem_delimiter, listitem_start, listitem_indent) = scan_listitem(&s[ix..]);
+        let (listitem_bytes, listitem_delimiter, _, listitem_indent) = scan_listitem(&s[ix..]);
         if listitem_bytes > 0 {
             // thematic breaks take precedence over listitems
             if scan_hrule(&s[ix..]) > 0 { break; }
@@ -555,8 +555,7 @@ fn parse_blocks(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
 
         let code_fence_size = scan_code_fence(&s[ix..]).0;
         if code_fence_size > 0 {
-            ix = parse_code_fence_block(&mut tree, s, ix, leading_spaces);
-            continue;
+            return parse_code_fence_block(&mut tree, s, ix, leading_spaces);
         }
 
         if let Some(html_end_tag) = get_html_end_tag(&s[ix..]) {

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -353,13 +353,14 @@ fn parse_paragraph(mut tree : &mut Tree<Item>, s : &str, mut ix : usize) -> usiz
     let mut last_soft_break = None;
     while ix < s.len() {
         let line_start = ix;
-        let (leading_bytes, leading_spaces) = scan_leading_space(&s[ix..], 0);
-        ix += leading_bytes;
 
         let container_scan = scan_containers(&tree, &s[ix..]);
         if container_scan.1 {
             ix += container_scan.0;
         }
+
+        let (leading_bytes, leading_spaces) = scan_leading_space(&s[ix..], 0);
+        ix += leading_bytes;
 
        
         let (setext_bytes, setext_level) = scan_setext_header(&s[ix..]);
@@ -377,7 +378,7 @@ fn parse_paragraph(mut tree : &mut Tree<Item>, s : &str, mut ix : usize) -> usiz
             break;
         }
 
-        if scan_paragraph_interrupt(&s[ix..]) {
+        if leading_spaces < 4 && scan_paragraph_interrupt(&s[ix..]) {
             // println!("paragraph interrupted at ix: {}, leading_spaces: {}", ix, leading_spaces);
             ix = line_start; 
             // println!("restart line at ix: {}", ix);
@@ -414,12 +415,12 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
         match tree.nodes[vertebra].item.body {
             ItemBody::BlockQuote => {
                 i += space_bytes;
-                if num_spaces >= 4 { return (i, false); }
+                if num_spaces >= 4 { return (0, false); }
                 let n = scan_blockquote_start(&text[i..]);
                 if n > 0 {
                     i += n
                 } else {
-                    return (i, false);
+                    return (0, false);
                 }
             },
             ItemBody::ListItem(indent) => {

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -433,6 +433,13 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
                     return (i, false);
                 }
             }
+            ItemBody::List(_, _, _) => {
+                // hrule interrupts list
+                let hrule_size = scan_hrule(&text[i..]);
+                if hrule_size > 0 {
+                    return (0, false);
+                }
+            }
             _ => (),
         }
     }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -530,7 +530,7 @@ fn parse_new_containers(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize 
             tree.append(Item {
                 start: ix,
                 end: ix, // TODO: set this correctly
-                body: ItemBody::ListItem(listitem_indent),
+                body: ItemBody::ListItem(listitem_indent + leading_spaces),
             });
             tree.push();
             ix += listitem_bytes;
@@ -538,6 +538,15 @@ fn parse_new_containers(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize 
         }
         break;
     }
+
+    // If we are at a ListItem node, we didn't see a new ListItem,
+    // so it's time to close the list.
+    if tree.cur != NIL {
+        if let ItemBody::ListItem(_) = tree.nodes[tree.cur].item.body {
+            tree.pop();
+        }
+    }
+
     if ix > leading_bytes + begin {
         return ix;
     } else {
@@ -879,11 +888,6 @@ fn detect_tight_list(tree: &Tree<Item>) -> bool {
                         return false;
                     }
                     this_listitem_lastborn = tree.nodes[this_listitem_lastborn].next;
-                }
-                // println!("lastborn was {}", this_listitem_lastborn);
-                if let ItemBody::BlankLine = tree.nodes[this_listitem_lastborn].item.body {
-                    // println!("found blankline lastborn {}", this_listitem_lastborn);
-                    return false;
                 }
             } // the else should panic!
         }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -425,7 +425,7 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
                 } else if scan_eol(&text[i..]).1 {
                     return (i, true);
                 }
-                i += space_bytes;
+                i += indent;
                 // println!("scanning past leading space to offset i: {}", i);
 
             },
@@ -443,7 +443,8 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
                 } else {
                     // println!("close icb, detach after {}", last_nonblank_child);
                     // tree.nodes[last_nonblank_child].next = NIL; // detach trailing blank lines
-                    return (i, false);
+                    // println!("did not find icb");
+                    return (0, false);
                 }
             }
             ItemBody::List(_, _, _) => {

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -85,18 +85,6 @@ impl<T> Tree<T> {
             return None;
         }
     }
-
-    // Look at the grandparent node, leaving tree in original state
-    fn peek_up_next(&mut self) -> Option<usize> {
-        if let Some(parent) = self.spine.pop() {
-            if let Some(grandparent) = self.spine.pop() {
-                self.spine.push(grandparent);
-                self.spine.push(parent);
-                return Some(grandparent);
-            }
-        }
-        return None;
-    }
 }
 
 #[derive(Debug)]

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -227,7 +227,7 @@ fn parse_indented_code_block(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> u
     } else {
         // if we never saw a nonblank chunk then
         // this isn't a valid codeblock, so detach it
-        tree.nodes[codeblock_parent].child = NIL;
+        if codeblock_parent != NIL { tree.nodes[codeblock_parent].child = NIL; }
         // pop to the codeblock, next pop will rise
         // to the parent, leaving detached codeblock behind
         tree.pop();

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -870,6 +870,9 @@ fn detect_tight_list(tree: &Tree<Item>) -> bool {
             let mut this_listitem_lastborn = tree.nodes[this_listitem].child;
             if this_listitem_lastborn != NIL {
                 while tree.nodes[this_listitem_lastborn].next != NIL {
+                    if let ItemBody::BlankLine = tree.nodes[this_listitem_lastborn].item.body {
+                        return false;
+                    }
                     this_listitem_lastborn = tree.nodes[this_listitem_lastborn].next;
                 }
                 // println!("lastborn was {}", this_listitem_lastborn);

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -238,6 +238,8 @@ fn parse_indented_code_block(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> u
     ix
 }
 
+// Starts with ix past all container marks.
+// Returns index of start of next line.
 fn parse_atx_header(mut tree: &mut Tree<Item>, s: &str, mut ix: usize,
     atx_level: i32, atx_size: usize) -> usize {
     
@@ -292,6 +294,7 @@ fn parse_atx_header(mut tree: &mut Tree<Item>, s: &str, mut ix: usize,
     ix
 }
 
+// Returns index of start of next line.
 fn parse_hrule(tree: &mut Tree<Item>, hrule_size: usize, mut ix: usize) -> usize {
     tree.append(Item {
         start: ix,
@@ -518,7 +521,8 @@ fn parse_new_containers(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize 
     }
 }
 
-// Used on a new line, after scan_containers and scan_new_containers
+// Used on a new line, after scan_containers and scan_new_containers.
+// Mutates tree as needed, and returns the start of the next line.
 fn parse_blocks(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     if ix >= s.len() { return ix; }
     let b = s.as_bytes()[ix];

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -435,8 +435,8 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
 
             },
             ItemBody::FencedCodeBlock(num_code_fence_chars, code_fence_char, _) => {
-                if let Some(code_fence_end) = scan_closing_code_fence(&text[i+space_bytes..], code_fence_char, num_code_fence_chars) {
-                    i += code_fence_end+space_bytes;
+                if let Some(code_fence_end) = scan_closing_code_fence(&text[i..], code_fence_char, num_code_fence_chars) {
+                    i += code_fence_end;
                     i += scan_eol(&text[i..]).0;
                     return (i, false);
                 }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -498,12 +498,28 @@ fn parse_new_containers(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize 
                 listitem_start = None;
             }
 
-            tree.append(Item {
-                start: ix,
-                end: ix, // TODO: set this correctly
-                body: ItemBody::List(listitem_indent, listitem_delimiter, listitem_start),
-            });
-            tree.push();
+            let mut need_push = true; // Are we starting a new list?
+            if let Some(parent) = tree.peek_up() {
+                match tree.nodes[parent].item.body {
+                    ItemBody::List(_, delim, _, _) if delim == listitem_delimiter => {
+                        need_push = false;
+                    },
+                    ItemBody::List(_, _, _, _) => {
+                        // A different delimiter indicates a new list
+                        tree.pop();
+                    },
+                    _ => {},
+                }
+            }
+            if need_push {
+                tree.append(Item {
+                    start: ix,
+                    end: ix, // TODO: set this correctly
+                    body: ItemBody::List(listitem_indent, listitem_delimiter, listitem_start, false),
+                });
+                tree.push();
+            }
+
             tree.append(Item {
                 start: ix,
                 end: ix, // TODO: set this correctly

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -466,7 +466,7 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> Option<usize> {
 
 // Used on a new line, after scan_containers
 // scans to first character after new container markers
-fn scan_new_containers(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
+fn parse_new_containers(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     let begin = ix;
     let leading_bytes = scan_leading_space(s, ix).0;
     loop {
@@ -495,7 +495,7 @@ fn scan_new_containers(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usi
 }
 
 // Used on a new line, after scan_containers and scan_new_containers
-fn scan_blocks(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
+fn parse_blocks(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     if ix >= s.len() { return ix; }
     let b = s.as_bytes()[ix];
     if b == b'\n' || b == b'\r' {
@@ -552,8 +552,8 @@ fn first_pass(s: &str) -> Tree<Item> {
     while ix < s.len() {
         while let None = scan_containers(&tree, &s[ix..]) { tree.pop(); }
         ix += scan_containers(&tree, &s[ix..]).unwrap();
-        ix = scan_new_containers(&mut tree, s, ix);
-        ix = scan_blocks(&mut tree, s, ix);
+        ix = parse_new_containers(&mut tree, s, ix);
+        ix = parse_blocks(&mut tree, s, ix);
     }
     tree
 }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -364,9 +364,10 @@ fn parse_paragraph(mut tree : &mut Tree<Item>, s : &str, mut ix : usize) -> usiz
         let line_start = ix;
 
         let container_scan = scan_containers(&tree, &s[ix..]);
-        if container_scan.1 {
-            ix += container_scan.0;
-        }
+        // println!("paragraph container scan. Closed: {}, bytes: {}", container_scan.1, container_scan.0);
+        // if container_scan.1 {
+        ix += container_scan.0;
+        // }
 
         let (leading_bytes, leading_spaces) = scan_leading_space(&s[ix..], 0);
         ix += leading_bytes;
@@ -429,7 +430,7 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
                 if n > 0 {
                     i += n
                 } else {
-                    return (0, false);
+                    return (i, false);
                 }
             },
             ItemBody::ListItem(indent) => {

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -126,6 +126,7 @@ impl Tree<Item> {
     }
 }
 
+#[allow(dead_code)]
 fn dump_tree(nodes: &Vec<Node<Item>>, mut ix: usize, level: usize) {
     while ix != NIL {
         let node = &nodes[ix];
@@ -284,7 +285,7 @@ fn parse_atx_header(mut tree: &mut Tree<Item>, s: &str, mut ix: usize,
     ix
 }
 
-fn parse_hrule(mut tree: &mut Tree<Item>, hrule_size: usize, mut ix: usize) -> usize {
+fn parse_hrule(tree: &mut Tree<Item>, hrule_size: usize, mut ix: usize) -> usize {
     tree.append(Item {
         start: ix,
         end: ix + hrule_size,
@@ -294,7 +295,7 @@ fn parse_hrule(mut tree: &mut Tree<Item>, hrule_size: usize, mut ix: usize) -> u
     ix
 }
 
-fn parse_code_fence_block(mut tree: &mut Tree<Item>, s: &str, mut ix: usize, indentation: usize) -> usize {
+fn parse_code_fence_block(tree: &mut Tree<Item>, s: &str, mut ix: usize, indentation: usize) -> usize {
     tree.append(Item {
         start: ix,
         end: 0, // set later
@@ -473,7 +474,7 @@ fn first_pass(s: &str) -> Tree<Item> {
                 continue;
             }
 
-            let (code_fence_size, code_fence_char) = scan_code_fence(&s[ix..]);
+            let code_fence_size = scan_code_fence(&s[ix..]).0;
             if code_fence_size > 0 {
                 ix = parse_code_fence_block(&mut tree, s, ix, leading_spaces);
                 continue;
@@ -648,6 +649,7 @@ pub struct Parser<'a> {
     tree: Tree<Item>,
 }
 
+#[allow(unused_variables)]
 impl<'a> Parser<'a> {
     pub fn new(text: &'a str) -> Parser<'a> {
         Parser::new_ext(text, Options::empty())

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -918,14 +918,22 @@ fn detect_tight_list(tree: &Tree<Item>) -> bool {
     let mut this_listitem = tree.nodes[tree.cur].child;
     while this_listitem != NIL {
         // println!("checking listitem node {}", this_listitem);
+        let on_lastborn_child = tree.nodes[this_listitem].next == NIL;
         if let ItemBody::ListItem(_) = tree.nodes[this_listitem].item.body {
-            let mut this_listitem_lastborn = tree.nodes[this_listitem].child;
-            if this_listitem_lastborn != NIL {
-                while tree.nodes[this_listitem_lastborn].next != NIL {
-                    if let ItemBody::BlankLine = tree.nodes[this_listitem_lastborn].item.body {
-                        return false;
+            let mut this_listitem_child = tree.nodes[this_listitem].child;
+            let mut on_firstborn_grandchild = true; 
+            if this_listitem_child != NIL {
+                while this_listitem_child != NIL {
+                    let on_lastborn_grandchild = tree.nodes[this_listitem_child].next == NIL;
+                    if let ItemBody::BlankLine = tree.nodes[this_listitem_child].item.body {
+                        // If the first line is blank, this does not trigger looseness.
+                        // Blanklines at the very end of a list also do not trigger looseness.
+                        if !on_firstborn_grandchild && !(on_lastborn_child && on_lastborn_grandchild) {  
+                            return false;
+                        }
                     }
-                    this_listitem_lastborn = tree.nodes[this_listitem_lastborn].next;
+                    on_firstborn_grandchild = false;
+                    this_listitem_child = tree.nodes[this_listitem_child].next;
                 }
             } // the else should panic!
         }

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -446,6 +446,11 @@ fn scan_containers(tree: &Tree<Item>, text: &str) -> (usize, bool) {
                 if !(num_spaces >= indent || scan_eol(&text[i..]).1) {
                     return (i, false);
                 } else if scan_eol(&text[i..]).1 {
+                    if let ItemBody::BlankLine = tree.nodes[tree.cur].item.body {
+                        if tree.nodes[vertebra].child == tree.cur {
+                            return (i, false);
+                        }
+                    }
                     return (i, true);
                 }
                 i += indent;

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -163,8 +163,6 @@ fn dump_tree(nodes: &Vec<Node<Item>>, mut ix: usize, level: usize) {
     }
 }
 
-
-
 // Return: number of bytes parsed
 fn parse_line(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     let start = ix;

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -224,10 +224,12 @@ pub fn scan_leading_space(text: &str, loc: usize) -> (usize, usize) {
 // return: start byte for code text in indented code line, or None
 // for a non-code line
 pub fn scan_code_line(text: &str) -> Option<usize> {
+    // println!("scanning for code line");
     let bytes = text.as_bytes();
     let mut num_spaces = 0;
     let mut i = 0;
     for &c in bytes {
+        // println!("saw char {}", c as char);
         if num_spaces == 4 { return Some(4); }
         match c {
             b' ' => num_spaces += 1,

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -224,12 +224,10 @@ pub fn scan_leading_space(text: &str, loc: usize) -> (usize, usize) {
 // return: start byte for code text in indented code line, or None
 // for a non-code line
 pub fn scan_code_line(text: &str) -> Option<usize> {
-    // println!("scanning for code line");
     let bytes = text.as_bytes();
     let mut num_spaces = 0;
     let mut i = 0;
     for &c in bytes {
-        // println!("saw char {}", c as char);
         if num_spaces == 4 { return Some(4); }
         match c {
             b' ' => num_spaces += 1,

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -469,6 +469,10 @@ pub fn scan_listitem(data: &str) -> (usize, u8, usize, usize) {
         postn = 1;
         postindent = 1;
     }
+    if let Some(_) = scan_blank_line(&data[w..]) {
+        postn = 0;
+        postindent = 1;
+    }
     (w + postn, c, start, w + postindent)
 }
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -307,7 +307,7 @@ pub fn scan_hrule(data: &str) -> usize {
                 break;
             }
             c2 if c2 == c => n += 1,
-            b' ' => (),
+            b' ' | b'\t' => (),
             _ => return 0
         }
         i += 1;

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -440,7 +440,7 @@ pub fn scan_blockquote_start(data: &str) -> usize {
     }
 }
 
-// return number of bytes scanned, delimeter, start index, and indent
+// return number of bytes scanned, delimiter, start index, and indent
 pub fn scan_listitem(data: &str) -> (usize, u8, usize, usize) {
     if data.is_empty() { return (0, 0, 0, 0); }
     let mut c = data.as_bytes()[0];

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -453,7 +453,7 @@ pub fn scan_listitem(data: &str) -> (usize, u8, usize, usize) {
             let mut i = 1;
             i += scan_while(&data[i..], is_digit);
             start = data[..i].parse().unwrap();
-            if i >= data.len() { return (0, 0, 0, 0); }
+            if i >= data.len() || i > 9 { return (0, 0, 0, 0); }
             c = data.as_bytes()[i];
             if !(c == b'.' || c == b')') { return (0, 0, 0, 0); }
             i + 1


### PR DESCRIPTION
I've implemented container blocks (blockquotes and lists) in the new algorithm. This ended up requiring many changes to leaf block handling as well. This now passes 363/621 spec tests.

The main loop (in first_pass) scans the text line-by-line. On each line, we first iterate over the spine of the tree to check that markings for containers are present. If not, we pop up the tree until all finished containers are closed. Then we scan for new containers and append them to the tree. Finally, we parse leaf blocks.

Code blocks and html blocks have been redone so that they are parsed one line at a time, because it simplifies the container logic.

Paragraphs are still parsed as multiple lines, because it seems like a straightforward way to implement lazy continuation of paragraph texts. 

Two key operations are handled as special cases during the second pass (tree parsing):
-   Loose list detection, and removal of trailing blank lines from indented code blocks. Loose lists are 
    detected with the help of non-html-generating BlankLine nodes. If a list is tight, we perform tree 
    surgery to excise paragraph tags.

-   Indented Code Block blankline removal is sort of split in two. The node containing the last non-blank node is recorded during tree construction, and everything after that is detached during tree parsing. Splitting it like this is favoring efficiency over readability of the code, and I'm not sure if it's the right trade-off.

I've also added a non-html-generating HTMLBlock node to parent raw html leaf blocks. This required a small change to html.rs, which I'm generally trying to avoid changing because it is client-facing. But I think it's clear that my change should not affect the correctness of HTML generation.

Most tests that should be passing are now passing. I'll note some exceptions that I found troublesome. The example numbers reference CommonMark v0.27:

**246**: The easy way to implement this is to make scan_paragraph_interrupt return false on blank list items. But this breaks example 244.

**265**: Here as well, it doesn't work to make scan_paragraph_interrupt return false on a numerical list item (with start_index != 1), which would seem like the easy fix. That would break example 263. John MacFarlane has expressed discomfort with this part of the spec (https://github.com/commonmark/cmark/issues/204).

**271 & 272**: I don't understand why the listitems with four spaces in front are legal... they seem to violate the definition.

**274**: This seems like it is in conflict with example 241. The blankline should terminate the list.

**284 & 285**: These point to a difficulty around handling blanklines at the end of lists. The blanklines should probably bubble up until they aren't the trailing node anymore. This has to be done during tree parsing since you don't know they are trailing until the first pass is over. I'm not sure yet how to do this correctly and efficiently.

I haven't implemented code fence info strings or HTML Type 7 yet. I'm not handling tabs correctly (which looks like it requires the synthesis of spaces in some cases). I haven't done anything about links. I believe the other failing tests before test 285 are due to parts of the inline handling that aren't implemented yet.