### PR TITLE
Handle code fence info string and HTML type 7 on new algorithm

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1434,9 +1434,9 @@ impl<'a> RawParser<'a> {
                 let n = self.scan_whitespace_inline(&data[i..]);
                 if n == 0 { break; }
                 i += n;
-                let n = scan_attribute_name(&data[i..]);
-                if n == 0 { break; }
-                i += n;
+                // let n = scan_attribute_name(&data[i..]);
+                // if n == 0 { break; }
+                // i += n;
                 let n = self.scan_whitespace_inline(&data[i..]);
                 if scan_ch(&data[i + n ..], b'=') != 0 {
                     i += n + 1;

--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -648,14 +648,13 @@ fn parse_blocks(mut tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
     let (num_code_fence_chars, code_fence_char) = scan_code_fence(&s[ix..]);
     if num_code_fence_chars > 0 {
         let nextline_offset = scan_nextline(&s[ix..]);
-        let info_string = s[ix+num_code_fence_chars..ix+nextline_offset].trim().to_string();
+        let info_string = unescape(s[ix+num_code_fence_chars..ix+nextline_offset].trim()).to_string();
         tree.append(Item {
             start: ix,
             end: 0, // set later
             body: ItemBody::FencedCodeBlock(num_code_fence_chars, code_fence_char, leading_spaces, info_string),
         });
         
-        // TODO: parse code fence info
         ix += scan_nextline(&s[ix..]);
 
         tree.push();

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -94,11 +94,7 @@ pub fn is_ascii_alphanumeric(c: u8) -> bool {
 }
 
 pub fn is_ascii_letterdigitdash(c: u8) -> bool {
-    match c {
-        b'-' => {return true;},
-        _ => {},
-    }
-    return is_ascii_alphanumeric(c);
+    c == b'-' || is_ascii_alphanumeric(c)
 }
 
 fn is_hexdigit(c: u8) -> bool {


### PR DESCRIPTION
@elynnyap and I got code fence info strings and html type 7 working in the new algorithm. Now passing 370/621 spec tests.

We're a little unsure about the memory management of code info strings. Currently they are being cloned in item_to_tag.