### PR TITLE
Make generated cargo tests easier to work with

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,6 +54,8 @@ fn generate_tests_from_spec() {
         let mut spec_rs = File::create(&rs_test_file)
                                .expect(&format!("Could not create {:?}", rs_test_file));
 
+        let spec_name = file_path.file_stem().unwrap().to_str().unwrap();
+
         let spec = Spec::new(&raw_spec);
         let mut n_tests = 0;
 
@@ -67,7 +69,7 @@ fn generate_tests_from_spec() {
                     r###"
 
     #[test]
-    fn spec_test_{i}() {{
+    fn {}_test_{i}_() {{
         let original = r##"{original}"##;
         let expected = r##"{expected}"##;
 
@@ -84,6 +86,7 @@ fn generate_tests_from_spec() {
 
         assert_eq!(expected, s);
     }}"###,
+                    spec_name,
                     i=i+1,
                     original=testcase.original,
                     expected=testcase.expected

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -5,7 +5,7 @@ extern crate pulldown_cmark;
 
 
     #[test]
-    fn spec_test_1() {
+    fn footnotes_test_1_() {
         let original = r##"Lorem ipsum.[^a]
 
 [^a]: Cool.
@@ -31,7 +31,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_2() {
+    fn footnotes_test_2_() {
         let original = r##"> This is the song that never ends.\
 > Yes it goes on and on my friends.[^lambchops]
 >
@@ -61,7 +61,7 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
     }
 
     #[test]
-    fn spec_test_3() {
+    fn footnotes_test_3_() {
         let original = r##"Songs that simply loop are a popular way to annoy people. [^examples]
 
 [^examples]:
@@ -94,7 +94,7 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
     }
 
     #[test]
-    fn spec_test_4() {
+    fn footnotes_test_4_() {
         let original = r##"[^lorem]: If heaven ever wishes to grant me a boon, it will be a total effacing of the results of a mere chance which fixed my eye on a certain stray piece of shelf-paper. It was nothing on which I would naturally have stumbled in the course of my daily round, for it was an old number of an Australian journal, the Sydney Bulletin for April 18, 1925. It had escaped even the cutting bureau which had at the time of its issuance been avidly collecting material for my uncle's research.
 
 I had largely given over my inquiries into what Professor Angell called the "Cthulhu Cult", and was visiting a learned friend in Paterson, New Jersey; the curator of a local museum and a mineralogist of note. Examining one day the reserve specimens roughly set on the storage shelves in a rear room of the museum, my eye was caught by an odd picture in one of the old papers spread beneath the stones. It was the Sydney Bulletin I have mentioned, for my friend had wide affiliations in all conceivable foreign parts; and the picture was a half-tone cut of a hideous stone image almost identical with that which Legrasse had found in the swamp.
@@ -120,7 +120,7 @@ I had largely given over my inquiries into what Professor Angell called the "Cth
     }
 
     #[test]
-    fn spec_test_5() {
+    fn footnotes_test_5_() {
         let original = r##"[^ipsum]: How much wood would a woodchuck chuck.
 
 If a woodchuck could chuck wood.
@@ -150,7 +150,7 @@ If a woodchuck could chuck wood.
     }
 
     #[test]
-    fn spec_test_6() {
+    fn footnotes_test_6_() {
         let original = r##"> He's also really stupid. [^why]
 >
 > [^why]: Because your mamma!
@@ -181,7 +181,7 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
     }
 
     #[test]
-    fn spec_test_7() {
+    fn footnotes_test_7_() {
         let original = r##"Nested footnotes are considered poor style. [^a] [^xkcd]
 
 [^a]: This does not mean that footnotes cannot reference each other. [^b]
@@ -226,7 +226,7 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
     }
 
     #[test]
-    fn spec_test_8() {
+    fn footnotes_test_8_() {
         let original = r##"[^Doh] Ray Me Fa So La Te Do! [^1]
 
 [^Doh]: I know. Wrong Doe. And it won't render right.

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -5,7 +5,7 @@ extern crate pulldown_cmark;
 
 
     #[test]
-    fn spec_test_1() {
+    fn spec_test_1_() {
         let original = r##"	foo	baz		bim
 "##;
         let expected = r##"<pre><code>foo	baz		bim
@@ -27,7 +27,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_2() {
+    fn spec_test_2_() {
         let original = r##"  	foo	baz		bim
 "##;
         let expected = r##"<pre><code>foo	baz		bim
@@ -49,7 +49,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_3() {
+    fn spec_test_3_() {
         let original = r##"    a	a
     ὐ	a
 "##;
@@ -73,7 +73,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_4() {
+    fn spec_test_4_() {
         let original = r##"  - foo
 
 	bar
@@ -101,7 +101,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_5() {
+    fn spec_test_5_() {
         let original = r##"- foo
 
 		bar
@@ -130,7 +130,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_6() {
+    fn spec_test_6_() {
         let original = r##">		foo
 "##;
         let expected = r##"<blockquote>
@@ -154,7 +154,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_7() {
+    fn spec_test_7_() {
         let original = r##"-		foo
 "##;
         let expected = r##"<ul>
@@ -180,7 +180,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_8() {
+    fn spec_test_8_() {
         let original = r##"    foo
 	bar
 "##;
@@ -204,7 +204,7 @@ bar
     }
 
     #[test]
-    fn spec_test_9() {
+    fn spec_test_9_() {
         let original = r##" - foo
    - bar
 	 - baz
@@ -237,7 +237,7 @@ bar
     }
 
     #[test]
-    fn spec_test_10() {
+    fn spec_test_10_() {
         let original = r##"#	Foo
 "##;
         let expected = r##"<h1>Foo</h1>
@@ -258,7 +258,7 @@ bar
     }
 
     #[test]
-    fn spec_test_11() {
+    fn spec_test_11_() {
         let original = r##"*	*	*	
 "##;
         let expected = r##"<hr />
@@ -279,7 +279,7 @@ bar
     }
 
     #[test]
-    fn spec_test_12() {
+    fn spec_test_12_() {
         let original = r##"- `one
 - two`
 "##;
@@ -304,7 +304,7 @@ bar
     }
 
     #[test]
-    fn spec_test_13() {
+    fn spec_test_13_() {
         let original = r##"***
 ---
 ___
@@ -329,7 +329,7 @@ ___
     }
 
     #[test]
-    fn spec_test_14() {
+    fn spec_test_14_() {
         let original = r##"+++
 "##;
         let expected = r##"<p>+++</p>
@@ -350,7 +350,7 @@ ___
     }
 
     #[test]
-    fn spec_test_15() {
+    fn spec_test_15_() {
         let original = r##"===
 "##;
         let expected = r##"<p>===</p>
@@ -371,7 +371,7 @@ ___
     }
 
     #[test]
-    fn spec_test_16() {
+    fn spec_test_16_() {
         let original = r##"--
 **
 __
@@ -396,7 +396,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_17() {
+    fn spec_test_17_() {
         let original = r##" ***
   ***
    ***
@@ -421,7 +421,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_18() {
+    fn spec_test_18_() {
         let original = r##"    ***
 "##;
         let expected = r##"<pre><code>***
@@ -443,7 +443,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_19() {
+    fn spec_test_19_() {
         let original = r##"Foo
     ***
 "##;
@@ -466,7 +466,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_20() {
+    fn spec_test_20_() {
         let original = r##"_____________________________________
 "##;
         let expected = r##"<hr />
@@ -487,7 +487,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_21() {
+    fn spec_test_21_() {
         let original = r##" - - -
 "##;
         let expected = r##"<hr />
@@ -508,7 +508,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_22() {
+    fn spec_test_22_() {
         let original = r##" **  * ** * ** * **
 "##;
         let expected = r##"<hr />
@@ -529,7 +529,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_23() {
+    fn spec_test_23_() {
         let original = r##"-     -      -      -
 "##;
         let expected = r##"<hr />
@@ -550,7 +550,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_24() {
+    fn spec_test_24_() {
         let original = r##"- - - -    
 "##;
         let expected = r##"<hr />
@@ -571,7 +571,7 @@ __</p>
     }
 
     #[test]
-    fn spec_test_25() {
+    fn spec_test_25_() {
         let original = r##"_ _ _ _ a
 
 a------
@@ -598,7 +598,7 @@ a------
     }
 
     #[test]
-    fn spec_test_26() {
+    fn spec_test_26_() {
         let original = r##" *-*
 "##;
         let expected = r##"<p><em>-</em></p>
@@ -619,7 +619,7 @@ a------
     }
 
     #[test]
-    fn spec_test_27() {
+    fn spec_test_27_() {
         let original = r##"- foo
 ***
 - bar
@@ -648,7 +648,7 @@ a------
     }
 
     #[test]
-    fn spec_test_28() {
+    fn spec_test_28_() {
         let original = r##"Foo
 ***
 bar
@@ -673,7 +673,7 @@ bar
     }
 
     #[test]
-    fn spec_test_29() {
+    fn spec_test_29_() {
         let original = r##"Foo
 ---
 bar
@@ -697,7 +697,7 @@ bar
     }
 
     #[test]
-    fn spec_test_30() {
+    fn spec_test_30_() {
         let original = r##"* Foo
 * * *
 * Bar
@@ -726,7 +726,7 @@ bar
     }
 
     #[test]
-    fn spec_test_31() {
+    fn spec_test_31_() {
         let original = r##"- Foo
 - * * *
 "##;
@@ -753,7 +753,7 @@ bar
     }
 
     #[test]
-    fn spec_test_32() {
+    fn spec_test_32_() {
         let original = r##"# foo
 ## foo
 ### foo
@@ -784,7 +784,7 @@ bar
     }
 
     #[test]
-    fn spec_test_33() {
+    fn spec_test_33_() {
         let original = r##"####### foo
 "##;
         let expected = r##"<p>####### foo</p>
@@ -805,7 +805,7 @@ bar
     }
 
     #[test]
-    fn spec_test_34() {
+    fn spec_test_34_() {
         let original = r##"#5 bolt
 
 #hashtag
@@ -829,7 +829,7 @@ bar
     }
 
     #[test]
-    fn spec_test_35() {
+    fn spec_test_35_() {
         let original = r##"\## foo
 "##;
         let expected = r##"<p>## foo</p>
@@ -850,7 +850,7 @@ bar
     }
 
     #[test]
-    fn spec_test_36() {
+    fn spec_test_36_() {
         let original = r##"# foo *bar* \*baz\*
 "##;
         let expected = r##"<h1>foo <em>bar</em> *baz*</h1>
@@ -871,7 +871,7 @@ bar
     }
 
     #[test]
-    fn spec_test_37() {
+    fn spec_test_37_() {
         let original = r##"#                  foo                     
 "##;
         let expected = r##"<h1>foo</h1>
@@ -892,7 +892,7 @@ bar
     }
 
     #[test]
-    fn spec_test_38() {
+    fn spec_test_38_() {
         let original = r##" ### foo
   ## foo
    # foo
@@ -917,7 +917,7 @@ bar
     }
 
     #[test]
-    fn spec_test_39() {
+    fn spec_test_39_() {
         let original = r##"    # foo
 "##;
         let expected = r##"<pre><code># foo
@@ -939,7 +939,7 @@ bar
     }
 
     #[test]
-    fn spec_test_40() {
+    fn spec_test_40_() {
         let original = r##"foo
     # bar
 "##;
@@ -962,7 +962,7 @@ bar
     }
 
     #[test]
-    fn spec_test_41() {
+    fn spec_test_41_() {
         let original = r##"## foo ##
   ###   bar    ###
 "##;
@@ -985,7 +985,7 @@ bar
     }
 
     #[test]
-    fn spec_test_42() {
+    fn spec_test_42_() {
         let original = r##"# foo ##################################
 ##### foo ##
 "##;
@@ -1008,7 +1008,7 @@ bar
     }
 
     #[test]
-    fn spec_test_43() {
+    fn spec_test_43_() {
         let original = r##"### foo ###     
 "##;
         let expected = r##"<h3>foo</h3>
@@ -1029,7 +1029,7 @@ bar
     }
 
     #[test]
-    fn spec_test_44() {
+    fn spec_test_44_() {
         let original = r##"### foo ### b
 "##;
         let expected = r##"<h3>foo ### b</h3>
@@ -1050,7 +1050,7 @@ bar
     }
 
     #[test]
-    fn spec_test_45() {
+    fn spec_test_45_() {
         let original = r##"# foo#
 "##;
         let expected = r##"<h1>foo#</h1>
@@ -1071,7 +1071,7 @@ bar
     }
 
     #[test]
-    fn spec_test_46() {
+    fn spec_test_46_() {
         let original = r##"### foo \###
 ## foo #\##
 # foo \#
@@ -1096,7 +1096,7 @@ bar
     }
 
     #[test]
-    fn spec_test_47() {
+    fn spec_test_47_() {
         let original = r##"****
 ## foo
 ****
@@ -1121,7 +1121,7 @@ bar
     }
 
     #[test]
-    fn spec_test_48() {
+    fn spec_test_48_() {
         let original = r##"Foo bar
 # baz
 Bar foo
@@ -1146,7 +1146,7 @@ Bar foo
     }
 
     #[test]
-    fn spec_test_49() {
+    fn spec_test_49_() {
         let original = r##"## 
 #
 ### ###
@@ -1171,7 +1171,7 @@ Bar foo
     }
 
     #[test]
-    fn spec_test_50() {
+    fn spec_test_50_() {
         let original = r##"Foo *bar*
 =========
 
@@ -1197,7 +1197,7 @@ Foo *bar*
     }
 
     #[test]
-    fn spec_test_51() {
+    fn spec_test_51_() {
         let original = r##"Foo *bar
 baz*
 ====
@@ -1221,7 +1221,7 @@ baz</em></h1>
     }
 
     #[test]
-    fn spec_test_52() {
+    fn spec_test_52_() {
         let original = r##"Foo
 -------------------------
 
@@ -1247,7 +1247,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_53() {
+    fn spec_test_53_() {
         let original = r##"   Foo
 ---
 
@@ -1277,7 +1277,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_54() {
+    fn spec_test_54_() {
         let original = r##"    Foo
     ---
 
@@ -1307,7 +1307,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_55() {
+    fn spec_test_55_() {
         let original = r##"Foo
    ----      
 "##;
@@ -1329,7 +1329,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_56() {
+    fn spec_test_56_() {
         let original = r##"Foo
     ---
 "##;
@@ -1352,7 +1352,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_57() {
+    fn spec_test_57_() {
         let original = r##"Foo
 = =
 
@@ -1380,7 +1380,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_58() {
+    fn spec_test_58_() {
         let original = r##"Foo  
 -----
 "##;
@@ -1402,7 +1402,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_59() {
+    fn spec_test_59_() {
         let original = r##"Foo\
 ----
 "##;
@@ -1424,7 +1424,7 @@ Foo
     }
 
     #[test]
-    fn spec_test_60() {
+    fn spec_test_60_() {
         let original = r##"`Foo
 ----
 `
@@ -1454,7 +1454,7 @@ of dashes"/>
     }
 
     #[test]
-    fn spec_test_61() {
+    fn spec_test_61_() {
         let original = r##"> Foo
 ---
 "##;
@@ -1479,7 +1479,7 @@ of dashes"/>
     }
 
     #[test]
-    fn spec_test_62() {
+    fn spec_test_62_() {
         let original = r##"> foo
 bar
 ===
@@ -1506,7 +1506,7 @@ bar
     }
 
     #[test]
-    fn spec_test_63() {
+    fn spec_test_63_() {
         let original = r##"- Foo
 ---
 "##;
@@ -1531,7 +1531,7 @@ bar
     }
 
     #[test]
-    fn spec_test_64() {
+    fn spec_test_64_() {
         let original = r##"Foo
 Bar
 ---
@@ -1555,7 +1555,7 @@ Bar</h2>
     }
 
     #[test]
-    fn spec_test_65() {
+    fn spec_test_65_() {
         let original = r##"---
 Foo
 ---
@@ -1584,7 +1584,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_66() {
+    fn spec_test_66_() {
         let original = r##"
 ====
 "##;
@@ -1606,7 +1606,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_67() {
+    fn spec_test_67_() {
         let original = r##"---
 ---
 "##;
@@ -1629,7 +1629,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_68() {
+    fn spec_test_68_() {
         let original = r##"- foo
 -----
 "##;
@@ -1654,7 +1654,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_69() {
+    fn spec_test_69_() {
         let original = r##"    foo
 ---
 "##;
@@ -1678,7 +1678,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_70() {
+    fn spec_test_70_() {
         let original = r##"> foo
 -----
 "##;
@@ -1703,7 +1703,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_71() {
+    fn spec_test_71_() {
         let original = r##"\> foo
 ------
 "##;
@@ -1725,7 +1725,7 @@ Baz
     }
 
     #[test]
-    fn spec_test_72() {
+    fn spec_test_72_() {
         let original = r##"Foo
 
 bar
@@ -1752,7 +1752,7 @@ baz
     }
 
     #[test]
-    fn spec_test_73() {
+    fn spec_test_73_() {
         let original = r##"Foo
 bar
 
@@ -1781,7 +1781,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_74() {
+    fn spec_test_74_() {
         let original = r##"Foo
 bar
 * * *
@@ -1808,7 +1808,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_75() {
+    fn spec_test_75_() {
         let original = r##"Foo
 bar
 \---
@@ -1835,7 +1835,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_76() {
+    fn spec_test_76_() {
         let original = r##"    a simple
       indented code block
 "##;
@@ -1859,7 +1859,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_77() {
+    fn spec_test_77_() {
         let original = r##"  - foo
 
     bar
@@ -1887,7 +1887,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_78() {
+    fn spec_test_78_() {
         let original = r##"1.  foo
 
     - bar
@@ -1917,7 +1917,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_79() {
+    fn spec_test_79_() {
         let original = r##"    <a/>
     *hi*
 
@@ -1945,7 +1945,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_80() {
+    fn spec_test_80_() {
         let original = r##"    chunk1
 
     chunk2
@@ -1979,7 +1979,7 @@ chunk3
     }
 
     #[test]
-    fn spec_test_81() {
+    fn spec_test_81_() {
         let original = r##"    chunk1
       
       chunk2
@@ -2005,7 +2005,7 @@ chunk3
     }
 
     #[test]
-    fn spec_test_82() {
+    fn spec_test_82_() {
         let original = r##"Foo
     bar
 
@@ -2029,7 +2029,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_83() {
+    fn spec_test_83_() {
         let original = r##"    foo
 bar
 "##;
@@ -2053,7 +2053,7 @@ bar
     }
 
     #[test]
-    fn spec_test_84() {
+    fn spec_test_84_() {
         let original = r##"# Heading
     foo
 Heading
@@ -2085,7 +2085,7 @@ Heading
     }
 
     #[test]
-    fn spec_test_85() {
+    fn spec_test_85_() {
         let original = r##"        foo
     bar
 "##;
@@ -2109,7 +2109,7 @@ bar
     }
 
     #[test]
-    fn spec_test_86() {
+    fn spec_test_86_() {
         let original = r##"
     
     foo
@@ -2135,7 +2135,7 @@ bar
     }
 
     #[test]
-    fn spec_test_87() {
+    fn spec_test_87_() {
         let original = r##"    foo  
 "##;
         let expected = r##"<pre><code>foo  
@@ -2157,7 +2157,7 @@ bar
     }
 
     #[test]
-    fn spec_test_88() {
+    fn spec_test_88_() {
         let original = r##"```
 <
  >
@@ -2183,7 +2183,7 @@ bar
     }
 
     #[test]
-    fn spec_test_89() {
+    fn spec_test_89_() {
         let original = r##"~~~
 <
  >
@@ -2209,7 +2209,7 @@ bar
     }
 
     #[test]
-    fn spec_test_90() {
+    fn spec_test_90_() {
         let original = r##"``
 foo
 ``
@@ -2232,7 +2232,7 @@ foo
     }
 
     #[test]
-    fn spec_test_91() {
+    fn spec_test_91_() {
         let original = r##"```
 aaa
 ~~~
@@ -2258,7 +2258,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_92() {
+    fn spec_test_92_() {
         let original = r##"~~~
 aaa
 ```
@@ -2284,7 +2284,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_93() {
+    fn spec_test_93_() {
         let original = r##"````
 aaa
 ```
@@ -2310,7 +2310,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_94() {
+    fn spec_test_94_() {
         let original = r##"~~~~
 aaa
 ~~~
@@ -2336,7 +2336,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_95() {
+    fn spec_test_95_() {
         let original = r##"```
 "##;
         let expected = r##"<pre><code></code></pre>
@@ -2357,7 +2357,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_96() {
+    fn spec_test_96_() {
         let original = r##"`````
 
 ```
@@ -2384,7 +2384,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_97() {
+    fn spec_test_97_() {
         let original = r##"> ```
 > aaa
 
@@ -2412,7 +2412,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_98() {
+    fn spec_test_98_() {
         let original = r##"```
 
   
@@ -2438,7 +2438,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_99() {
+    fn spec_test_99_() {
         let original = r##"```
 ```
 "##;
@@ -2460,7 +2460,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_100() {
+    fn spec_test_100_() {
         let original = r##" ```
  aaa
 aaa
@@ -2486,7 +2486,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_101() {
+    fn spec_test_101_() {
         let original = r##"  ```
 aaa
   aaa
@@ -2514,7 +2514,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_102() {
+    fn spec_test_102_() {
         let original = r##"   ```
    aaa
     aaa
@@ -2542,7 +2542,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_103() {
+    fn spec_test_103_() {
         let original = r##"    ```
     aaa
     ```
@@ -2568,7 +2568,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_104() {
+    fn spec_test_104_() {
         let original = r##"```
 aaa
   ```
@@ -2592,7 +2592,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_105() {
+    fn spec_test_105_() {
         let original = r##"   ```
 aaa
   ```
@@ -2616,7 +2616,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_106() {
+    fn spec_test_106_() {
         let original = r##"```
 aaa
     ```
@@ -2641,7 +2641,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_107() {
+    fn spec_test_107_() {
         let original = r##"``` ```
 aaa
 "##;
@@ -2664,7 +2664,7 @@ aaa</p>
     }
 
     #[test]
-    fn spec_test_108() {
+    fn spec_test_108_() {
         let original = r##"~~~~~~
 aaa
 ~~~ ~~
@@ -2689,7 +2689,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_109() {
+    fn spec_test_109_() {
         let original = r##"foo
 ```
 bar
@@ -2717,7 +2717,7 @@ baz
     }
 
     #[test]
-    fn spec_test_110() {
+    fn spec_test_110_() {
         let original = r##"foo
 ---
 ~~~
@@ -2746,7 +2746,7 @@ bar
     }
 
     #[test]
-    fn spec_test_111() {
+    fn spec_test_111_() {
         let original = r##"```ruby
 def foo(x)
   return 3
@@ -2774,7 +2774,7 @@ end
     }
 
     #[test]
-    fn spec_test_112() {
+    fn spec_test_112_() {
         let original = r##"~~~~    ruby startline=3 $%@#$
 def foo(x)
   return 3
@@ -2802,7 +2802,7 @@ end
     }
 
     #[test]
-    fn spec_test_113() {
+    fn spec_test_113_() {
         let original = r##"````;
 ````
 "##;
@@ -2824,7 +2824,7 @@ end
     }
 
     #[test]
-    fn spec_test_114() {
+    fn spec_test_114_() {
         let original = r##"``` aa ```
 foo
 "##;
@@ -2847,7 +2847,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_115() {
+    fn spec_test_115_() {
         let original = r##"```
 ``` aaa
 ```
@@ -2871,7 +2871,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_116() {
+    fn spec_test_116_() {
         let original = r##"<table><tr><td>
 <pre>
 **Hello**,
@@ -2903,7 +2903,7 @@ _world_.
     }
 
     #[test]
-    fn spec_test_117() {
+    fn spec_test_117_() {
         let original = r##"<table>
   <tr>
     <td>
@@ -2939,7 +2939,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_118() {
+    fn spec_test_118_() {
         let original = r##" <div>
   *hello*
          <foo><a>
@@ -2964,7 +2964,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_119() {
+    fn spec_test_119_() {
         let original = r##"</div>
 *foo*
 "##;
@@ -2987,7 +2987,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_120() {
+    fn spec_test_120_() {
         let original = r##"<DIV CLASS="foo">
 
 *Markdown*
@@ -3014,7 +3014,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_121() {
+    fn spec_test_121_() {
         let original = r##"<div id="foo"
   class="bar">
 </div>
@@ -3039,7 +3039,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_122() {
+    fn spec_test_122_() {
         let original = r##"<div id="foo" class="bar
   baz">
 </div>
@@ -3064,7 +3064,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_123() {
+    fn spec_test_123_() {
         let original = r##"<div>
 *foo*
 
@@ -3090,7 +3090,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_124() {
+    fn spec_test_124_() {
         let original = r##"<div id="foo"
 *hi*
 "##;
@@ -3113,7 +3113,7 @@ okay.
     }
 
     #[test]
-    fn spec_test_125() {
+    fn spec_test_125_() {
         let original = r##"<div class
 foo
 "##;
@@ -3136,7 +3136,7 @@ foo
     }
 
     #[test]
-    fn spec_test_126() {
+    fn spec_test_126_() {
         let original = r##"<div *???-&&&-<---
 *foo*
 "##;
@@ -3159,7 +3159,7 @@ foo
     }
 
     #[test]
-    fn spec_test_127() {
+    fn spec_test_127_() {
         let original = r##"<div><a href="bar">*foo*</a></div>
 "##;
         let expected = r##"<div><a href="bar">*foo*</a></div>
@@ -3180,7 +3180,7 @@ foo
     }
 
     #[test]
-    fn spec_test_128() {
+    fn spec_test_128_() {
         let original = r##"<table><tr><td>
 foo
 </td></tr></table>
@@ -3205,7 +3205,7 @@ foo
     }
 
     #[test]
-    fn spec_test_129() {
+    fn spec_test_129_() {
         let original = r##"<div></div>
 ``` c
 int x = 33;
@@ -3232,7 +3232,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_130() {
+    fn spec_test_130_() {
         let original = r##"<a href="foo">
 *bar*
 </a>
@@ -3257,7 +3257,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_131() {
+    fn spec_test_131_() {
         let original = r##"<Warning>
 *bar*
 </Warning>
@@ -3282,7 +3282,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_132() {
+    fn spec_test_132_() {
         let original = r##"<i class="foo">
 *bar*
 </i>
@@ -3307,7 +3307,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_133() {
+    fn spec_test_133_() {
         let original = r##"</ins>
 *bar*
 "##;
@@ -3330,7 +3330,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_134() {
+    fn spec_test_134_() {
         let original = r##"<del>
 *foo*
 </del>
@@ -3355,7 +3355,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_135() {
+    fn spec_test_135_() {
         let original = r##"<del>
 
 *foo*
@@ -3382,7 +3382,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_136() {
+    fn spec_test_136_() {
         let original = r##"<del>*foo*</del>
 "##;
         let expected = r##"<p><del><em>foo</em></del></p>
@@ -3403,7 +3403,7 @@ int x = 33;
     }
 
     #[test]
-    fn spec_test_137() {
+    fn spec_test_137_() {
         let original = r##"<pre language="haskell"><code>
 import Text.HTML.TagSoup
 
@@ -3436,7 +3436,7 @@ main = print $ parseTags tags
     }
 
     #[test]
-    fn spec_test_138() {
+    fn spec_test_138_() {
         let original = r##"<script type="text/javascript">
 // JavaScript example
 
@@ -3467,7 +3467,7 @@ document.getElementById("demo").innerHTML = "Hello JavaScript!";
     }
 
     #[test]
-    fn spec_test_139() {
+    fn spec_test_139_() {
         let original = r##"<style
   type="text/css">
 h1 {color:red;}
@@ -3500,7 +3500,7 @@ p {color:blue;}
     }
 
     #[test]
-    fn spec_test_140() {
+    fn spec_test_140_() {
         let original = r##"<style
   type="text/css">
 
@@ -3527,7 +3527,7 @@ foo
     }
 
     #[test]
-    fn spec_test_141() {
+    fn spec_test_141_() {
         let original = r##"> <div>
 > foo
 
@@ -3555,7 +3555,7 @@ foo
     }
 
     #[test]
-    fn spec_test_142() {
+    fn spec_test_142_() {
         let original = r##"- <div>
 - foo
 "##;
@@ -3582,7 +3582,7 @@ foo
     }
 
     #[test]
-    fn spec_test_143() {
+    fn spec_test_143_() {
         let original = r##"<style>p{color:red;}</style>
 *foo*
 "##;
@@ -3605,7 +3605,7 @@ foo
     }
 
     #[test]
-    fn spec_test_144() {
+    fn spec_test_144_() {
         let original = r##"<!-- foo -->*bar*
 *baz*
 "##;
@@ -3628,7 +3628,7 @@ foo
     }
 
     #[test]
-    fn spec_test_145() {
+    fn spec_test_145_() {
         let original = r##"<script>
 foo
 </script>1. *bar*
@@ -3653,7 +3653,7 @@ foo
     }
 
     #[test]
-    fn spec_test_146() {
+    fn spec_test_146_() {
         let original = r##"<!-- Foo
 
 bar
@@ -3682,7 +3682,7 @@ bar
     }
 
     #[test]
-    fn spec_test_147() {
+    fn spec_test_147_() {
         let original = r##"<?php
 
   echo '>';
@@ -3713,7 +3713,7 @@ okay
     }
 
     #[test]
-    fn spec_test_148() {
+    fn spec_test_148_() {
         let original = r##"<!DOCTYPE html>
 "##;
         let expected = r##"<!DOCTYPE html>
@@ -3734,7 +3734,7 @@ okay
     }
 
     #[test]
-    fn spec_test_149() {
+    fn spec_test_149_() {
         let original = r##"<![CDATA[
 function matchwo(a,b)
 {
@@ -3779,7 +3779,7 @@ function matchwo(a,b)
     }
 
     #[test]
-    fn spec_test_150() {
+    fn spec_test_150_() {
         let original = r##"  <!-- foo -->
 
     <!-- foo -->
@@ -3804,7 +3804,7 @@ function matchwo(a,b)
     }
 
     #[test]
-    fn spec_test_151() {
+    fn spec_test_151_() {
         let original = r##"  <div>
 
     <div>
@@ -3829,7 +3829,7 @@ function matchwo(a,b)
     }
 
     #[test]
-    fn spec_test_152() {
+    fn spec_test_152_() {
         let original = r##"Foo
 <div>
 bar
@@ -3856,7 +3856,7 @@ bar
     }
 
     #[test]
-    fn spec_test_153() {
+    fn spec_test_153_() {
         let original = r##"<div>
 bar
 </div>
@@ -3883,7 +3883,7 @@ bar
     }
 
     #[test]
-    fn spec_test_154() {
+    fn spec_test_154_() {
         let original = r##"Foo
 <a href="bar">
 baz
@@ -3908,7 +3908,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_155() {
+    fn spec_test_155_() {
         let original = r##"<div>
 
 *Emphasized* text.
@@ -3935,7 +3935,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_156() {
+    fn spec_test_156_() {
         let original = r##"<div>
 *Emphasized* text.
 </div>
@@ -3960,7 +3960,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_157() {
+    fn spec_test_157_() {
         let original = r##"<table>
 
 <tr>
@@ -3997,7 +3997,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_158() {
+    fn spec_test_158_() {
         let original = r##"<table>
 
   <tr>
@@ -4035,7 +4035,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_159() {
+    fn spec_test_159_() {
         let original = r##"[foo]: /url "title"
 
 [foo]
@@ -4058,7 +4058,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_160() {
+    fn spec_test_160_() {
         let original = r##"   [foo]: 
       /url  
            'the title'  
@@ -4083,7 +4083,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_161() {
+    fn spec_test_161_() {
         let original = r##"[Foo*bar\]]:my_(url) 'title (with parens)'
 
 [Foo*bar\]]
@@ -4106,7 +4106,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_162() {
+    fn spec_test_162_() {
         let original = r##"[Foo bar]:
 <my%20url>
 'title'
@@ -4131,7 +4131,7 @@ Hi
     }
 
     #[test]
-    fn spec_test_163() {
+    fn spec_test_163_() {
         let original = r##"[foo]: /url '
 title
 line1
@@ -4162,7 +4162,7 @@ line2
     }
 
     #[test]
-    fn spec_test_164() {
+    fn spec_test_164_() {
         let original = r##"[foo]: /url 'title
 
 with blank line'
@@ -4189,7 +4189,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_165() {
+    fn spec_test_165_() {
         let original = r##"[foo]:
 /url
 
@@ -4213,7 +4213,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_166() {
+    fn spec_test_166_() {
         let original = r##"[foo]:
 
 [foo]
@@ -4237,7 +4237,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_167() {
+    fn spec_test_167_() {
         let original = r##"[foo]: /url\bar\*baz "foo\"bar\baz"
 
 [foo]
@@ -4260,7 +4260,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_168() {
+    fn spec_test_168_() {
         let original = r##"[foo]
 
 [foo]: url
@@ -4283,7 +4283,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_169() {
+    fn spec_test_169_() {
         let original = r##"[foo]
 
 [foo]: first
@@ -4307,7 +4307,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_170() {
+    fn spec_test_170_() {
         let original = r##"[FOO]: /url
 
 [Foo]
@@ -4330,7 +4330,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_171() {
+    fn spec_test_171_() {
         let original = r##"[ΑΓΩ]: /φου
 
 [αγω]
@@ -4353,7 +4353,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_172() {
+    fn spec_test_172_() {
         let original = r##"[foo]: /url
 "##;
         let expected = r##""##;
@@ -4373,7 +4373,7 @@ with blank line'
     }
 
     #[test]
-    fn spec_test_173() {
+    fn spec_test_173_() {
         let original = r##"[
 foo
 ]: /url
@@ -4397,7 +4397,7 @@ bar
     }
 
     #[test]
-    fn spec_test_174() {
+    fn spec_test_174_() {
         let original = r##"[foo]: /url "title" ok
 "##;
         let expected = r##"<p>[foo]: /url &quot;title&quot; ok</p>
@@ -4418,7 +4418,7 @@ bar
     }
 
     #[test]
-    fn spec_test_175() {
+    fn spec_test_175_() {
         let original = r##"[foo]: /url
 "title" ok
 "##;
@@ -4440,7 +4440,7 @@ bar
     }
 
     #[test]
-    fn spec_test_176() {
+    fn spec_test_176_() {
         let original = r##"    [foo]: /url "title"
 
 [foo]
@@ -4465,7 +4465,7 @@ bar
     }
 
     #[test]
-    fn spec_test_177() {
+    fn spec_test_177_() {
         let original = r##"```
 [foo]: /url
 ```
@@ -4492,7 +4492,7 @@ bar
     }
 
     #[test]
-    fn spec_test_178() {
+    fn spec_test_178_() {
         let original = r##"Foo
 [bar]: /baz
 
@@ -4518,7 +4518,7 @@ bar
     }
 
     #[test]
-    fn spec_test_179() {
+    fn spec_test_179_() {
         let original = r##"# [Foo]
 [foo]: /url
 > bar
@@ -4544,7 +4544,7 @@ bar
     }
 
     #[test]
-    fn spec_test_180() {
+    fn spec_test_180_() {
         let original = r##"[foo]: /foo-url "foo"
 [bar]: /bar-url
   "bar"
@@ -4574,7 +4574,7 @@ bar
     }
 
     #[test]
-    fn spec_test_181() {
+    fn spec_test_181_() {
         let original = r##"[foo]
 
 > [foo]: /url
@@ -4599,7 +4599,7 @@ bar
     }
 
     #[test]
-    fn spec_test_182() {
+    fn spec_test_182_() {
         let original = r##"aaa
 
 bbb
@@ -4623,7 +4623,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_183() {
+    fn spec_test_183_() {
         let original = r##"aaa
 bbb
 
@@ -4651,7 +4651,7 @@ ddd</p>
     }
 
     #[test]
-    fn spec_test_184() {
+    fn spec_test_184_() {
         let original = r##"aaa
 
 
@@ -4676,7 +4676,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_185() {
+    fn spec_test_185_() {
         let original = r##"  aaa
  bbb
 "##;
@@ -4699,7 +4699,7 @@ bbb</p>
     }
 
     #[test]
-    fn spec_test_186() {
+    fn spec_test_186_() {
         let original = r##"aaa
              bbb
                                        ccc
@@ -4724,7 +4724,7 @@ ccc</p>
     }
 
     #[test]
-    fn spec_test_187() {
+    fn spec_test_187_() {
         let original = r##"   aaa
 bbb
 "##;
@@ -4747,7 +4747,7 @@ bbb</p>
     }
 
     #[test]
-    fn spec_test_188() {
+    fn spec_test_188_() {
         let original = r##"    aaa
 bbb
 "##;
@@ -4771,7 +4771,7 @@ bbb
     }
 
     #[test]
-    fn spec_test_189() {
+    fn spec_test_189_() {
         let original = r##"aaa     
 bbb     
 "##;
@@ -4794,7 +4794,7 @@ bbb</p>
     }
 
     #[test]
-    fn spec_test_190() {
+    fn spec_test_190_() {
         let original = r##"  
 
 aaa
@@ -4823,7 +4823,7 @@ aaa
     }
 
     #[test]
-    fn spec_test_191() {
+    fn spec_test_191_() {
         let original = r##"> # Foo
 > bar
 > baz
@@ -4850,7 +4850,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_192() {
+    fn spec_test_192_() {
         let original = r##"># Foo
 >bar
 > baz
@@ -4877,7 +4877,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_193() {
+    fn spec_test_193_() {
         let original = r##"   > # Foo
    > bar
  > baz
@@ -4904,7 +4904,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_194() {
+    fn spec_test_194_() {
         let original = r##"    > # Foo
     > bar
     > baz
@@ -4930,7 +4930,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_195() {
+    fn spec_test_195_() {
         let original = r##"> # Foo
 > bar
 baz
@@ -4957,7 +4957,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_196() {
+    fn spec_test_196_() {
         let original = r##"> bar
 baz
 > foo
@@ -4984,7 +4984,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_197() {
+    fn spec_test_197_() {
         let original = r##"> foo
 ---
 "##;
@@ -5009,7 +5009,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_198() {
+    fn spec_test_198_() {
         let original = r##"> - foo
 - bar
 "##;
@@ -5038,7 +5038,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_199() {
+    fn spec_test_199_() {
         let original = r##">     foo
     bar
 "##;
@@ -5065,7 +5065,7 @@ foo</p>
     }
 
     #[test]
-    fn spec_test_200() {
+    fn spec_test_200_() {
         let original = r##"> ```
 foo
 ```
@@ -5092,7 +5092,7 @@ foo
     }
 
     #[test]
-    fn spec_test_201() {
+    fn spec_test_201_() {
         let original = r##"> foo
     - bar
 "##;
@@ -5117,7 +5117,7 @@ foo
     }
 
     #[test]
-    fn spec_test_202() {
+    fn spec_test_202_() {
         let original = r##">
 "##;
         let expected = r##"<blockquote>
@@ -5139,7 +5139,7 @@ foo
     }
 
     #[test]
-    fn spec_test_203() {
+    fn spec_test_203_() {
         let original = r##">
 >  
 > 
@@ -5163,7 +5163,7 @@ foo
     }
 
     #[test]
-    fn spec_test_204() {
+    fn spec_test_204_() {
         let original = r##">
 > foo
 >  
@@ -5188,7 +5188,7 @@ foo
     }
 
     #[test]
-    fn spec_test_205() {
+    fn spec_test_205_() {
         let original = r##"> foo
 
 > bar
@@ -5216,7 +5216,7 @@ foo
     }
 
     #[test]
-    fn spec_test_206() {
+    fn spec_test_206_() {
         let original = r##"> foo
 > bar
 "##;
@@ -5241,7 +5241,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_207() {
+    fn spec_test_207_() {
         let original = r##"> foo
 >
 > bar
@@ -5267,7 +5267,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_208() {
+    fn spec_test_208_() {
         let original = r##"foo
 > bar
 "##;
@@ -5292,7 +5292,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_209() {
+    fn spec_test_209_() {
         let original = r##"> aaa
 ***
 > bbb
@@ -5321,7 +5321,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_210() {
+    fn spec_test_210_() {
         let original = r##"> bar
 baz
 "##;
@@ -5346,7 +5346,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_211() {
+    fn spec_test_211_() {
         let original = r##"> bar
 
 baz
@@ -5372,7 +5372,7 @@ baz
     }
 
     #[test]
-    fn spec_test_212() {
+    fn spec_test_212_() {
         let original = r##"> bar
 >
 baz
@@ -5398,7 +5398,7 @@ baz
     }
 
     #[test]
-    fn spec_test_213() {
+    fn spec_test_213_() {
         let original = r##"> > > foo
 bar
 "##;
@@ -5427,7 +5427,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_214() {
+    fn spec_test_214_() {
         let original = r##">>> foo
 > bar
 >>baz
@@ -5458,7 +5458,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_215() {
+    fn spec_test_215_() {
         let original = r##">     code
 
 >    not code
@@ -5487,7 +5487,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_216() {
+    fn spec_test_216_() {
         let original = r##"A paragraph
 with two lines.
 
@@ -5519,7 +5519,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_217() {
+    fn spec_test_217_() {
         let original = r##"1.  A paragraph
     with two lines.
 
@@ -5555,7 +5555,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_218() {
+    fn spec_test_218_() {
         let original = r##"- one
 
  two
@@ -5581,7 +5581,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_219() {
+    fn spec_test_219_() {
         let original = r##"- one
 
   two
@@ -5609,7 +5609,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_220() {
+    fn spec_test_220_() {
         let original = r##" -    one
 
      two
@@ -5636,7 +5636,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_221() {
+    fn spec_test_221_() {
         let original = r##" -    one
 
       two
@@ -5664,7 +5664,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_222() {
+    fn spec_test_222_() {
         let original = r##"   > > 1.  one
 >>
 >>     two
@@ -5696,7 +5696,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_223() {
+    fn spec_test_223_() {
         let original = r##">>- one
 >>
   >  > two
@@ -5726,7 +5726,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_224() {
+    fn spec_test_224_() {
         let original = r##"-one
 
 2.two
@@ -5750,7 +5750,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_225() {
+    fn spec_test_225_() {
         let original = r##"- foo
 
 
@@ -5779,7 +5779,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_226() {
+    fn spec_test_226_() {
         let original = r##"1.  foo
 
     ```
@@ -5818,7 +5818,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_227() {
+    fn spec_test_227_() {
         let original = r##"- Foo
 
       bar
@@ -5853,7 +5853,7 @@ baz
     }
 
     #[test]
-    fn spec_test_228() {
+    fn spec_test_228_() {
         let original = r##"123456789. ok
 "##;
         let expected = r##"<ol start="123456789">
@@ -5876,7 +5876,7 @@ baz
     }
 
     #[test]
-    fn spec_test_229() {
+    fn spec_test_229_() {
         let original = r##"1234567890. not ok
 "##;
         let expected = r##"<p>1234567890. not ok</p>
@@ -5897,7 +5897,7 @@ baz
     }
 
     #[test]
-    fn spec_test_230() {
+    fn spec_test_230_() {
         let original = r##"0. ok
 "##;
         let expected = r##"<ol start="0">
@@ -5920,7 +5920,7 @@ baz
     }
 
     #[test]
-    fn spec_test_231() {
+    fn spec_test_231_() {
         let original = r##"003. ok
 "##;
         let expected = r##"<ol start="3">
@@ -5943,7 +5943,7 @@ baz
     }
 
     #[test]
-    fn spec_test_232() {
+    fn spec_test_232_() {
         let original = r##"-1. not ok
 "##;
         let expected = r##"<p>-1. not ok</p>
@@ -5964,7 +5964,7 @@ baz
     }
 
     #[test]
-    fn spec_test_233() {
+    fn spec_test_233_() {
         let original = r##"- foo
 
       bar
@@ -5993,7 +5993,7 @@ baz
     }
 
     #[test]
-    fn spec_test_234() {
+    fn spec_test_234_() {
         let original = r##"  10.  foo
 
            bar
@@ -6022,7 +6022,7 @@ baz
     }
 
     #[test]
-    fn spec_test_235() {
+    fn spec_test_235_() {
         let original = r##"    indented code
 
 paragraph
@@ -6051,7 +6051,7 @@ paragraph
     }
 
     #[test]
-    fn spec_test_236() {
+    fn spec_test_236_() {
         let original = r##"1.     indented code
 
    paragraph
@@ -6084,7 +6084,7 @@ paragraph
     }
 
     #[test]
-    fn spec_test_237() {
+    fn spec_test_237_() {
         let original = r##"1.      indented code
 
    paragraph
@@ -6117,7 +6117,7 @@ paragraph
     }
 
     #[test]
-    fn spec_test_238() {
+    fn spec_test_238_() {
         let original = r##"   foo
 
 bar
@@ -6141,7 +6141,7 @@ bar
     }
 
     #[test]
-    fn spec_test_239() {
+    fn spec_test_239_() {
         let original = r##"-    foo
 
   bar
@@ -6167,7 +6167,7 @@ bar
     }
 
     #[test]
-    fn spec_test_240() {
+    fn spec_test_240_() {
         let original = r##"-  foo
 
    bar
@@ -6195,7 +6195,7 @@ bar
     }
 
     #[test]
-    fn spec_test_241() {
+    fn spec_test_241_() {
         let original = r##"-
   foo
 -
@@ -6233,7 +6233,7 @@ bar
     }
 
     #[test]
-    fn spec_test_242() {
+    fn spec_test_242_() {
         let original = r##"-   
   foo
 "##;
@@ -6257,7 +6257,7 @@ bar
     }
 
     #[test]
-    fn spec_test_243() {
+    fn spec_test_243_() {
         let original = r##"-
 
   foo
@@ -6283,7 +6283,7 @@ bar
     }
 
     #[test]
-    fn spec_test_244() {
+    fn spec_test_244_() {
         let original = r##"- foo
 -
 - bar
@@ -6310,7 +6310,7 @@ bar
     }
 
     #[test]
-    fn spec_test_245() {
+    fn spec_test_245_() {
         let original = r##"- foo
 -   
 - bar
@@ -6337,7 +6337,7 @@ bar
     }
 
     #[test]
-    fn spec_test_246() {
+    fn spec_test_246_() {
         let original = r##"1. foo
 2.
 3. bar
@@ -6364,7 +6364,7 @@ bar
     }
 
     #[test]
-    fn spec_test_247() {
+    fn spec_test_247_() {
         let original = r##"*
 "##;
         let expected = r##"<ul>
@@ -6387,7 +6387,7 @@ bar
     }
 
     #[test]
-    fn spec_test_248() {
+    fn spec_test_248_() {
         let original = r##"foo
 *
 
@@ -6415,7 +6415,7 @@ foo
     }
 
     #[test]
-    fn spec_test_249() {
+    fn spec_test_249_() {
         let original = r##" 1.  A paragraph
      with two lines.
 
@@ -6451,7 +6451,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_250() {
+    fn spec_test_250_() {
         let original = r##"  1.  A paragraph
       with two lines.
 
@@ -6487,7 +6487,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_251() {
+    fn spec_test_251_() {
         let original = r##"   1.  A paragraph
        with two lines.
 
@@ -6523,7 +6523,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_252() {
+    fn spec_test_252_() {
         let original = r##"    1.  A paragraph
         with two lines.
 
@@ -6555,7 +6555,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_253() {
+    fn spec_test_253_() {
         let original = r##"  1.  A paragraph
 with two lines.
 
@@ -6591,7 +6591,7 @@ with two lines.</p>
     }
 
     #[test]
-    fn spec_test_254() {
+    fn spec_test_254_() {
         let original = r##"  1.  A paragraph
     with two lines.
 "##;
@@ -6616,7 +6616,7 @@ with two lines.</li>
     }
 
     #[test]
-    fn spec_test_255() {
+    fn spec_test_255_() {
         let original = r##"> 1. > Blockquote
 continued here.
 "##;
@@ -6647,7 +6647,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_256() {
+    fn spec_test_256_() {
         let original = r##"> 1. > Blockquote
 > continued here.
 "##;
@@ -6678,7 +6678,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_257() {
+    fn spec_test_257_() {
         let original = r##"- foo
   - bar
     - baz
@@ -6716,7 +6716,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_258() {
+    fn spec_test_258_() {
         let original = r##"- foo
  - bar
   - baz
@@ -6745,7 +6745,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_259() {
+    fn spec_test_259_() {
         let original = r##"10) foo
     - bar
 "##;
@@ -6773,7 +6773,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_260() {
+    fn spec_test_260_() {
         let original = r##"10) foo
    - bar
 "##;
@@ -6800,7 +6800,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_261() {
+    fn spec_test_261_() {
         let original = r##"- - foo
 "##;
         let expected = r##"<ul>
@@ -6827,7 +6827,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_262() {
+    fn spec_test_262_() {
         let original = r##"1. - 2. foo
 "##;
         let expected = r##"<ol>
@@ -6858,7 +6858,7 @@ continued here.</p>
     }
 
     #[test]
-    fn spec_test_263() {
+    fn spec_test_263_() {
         let original = r##"- # Foo
 - Bar
   ---
@@ -6889,7 +6889,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_264() {
+    fn spec_test_264_() {
         let original = r##"- foo
 - bar
 + baz
@@ -6918,7 +6918,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_265() {
+    fn spec_test_265_() {
         let original = r##"1. foo
 2. bar
 3) baz
@@ -6947,7 +6947,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_266() {
+    fn spec_test_266_() {
         let original = r##"Foo
 - bar
 - baz
@@ -6974,7 +6974,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_267() {
+    fn spec_test_267_() {
         let original = r##"The number of windows in my house is
 14.  The number of doors is 6.
 "##;
@@ -6997,7 +6997,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_268() {
+    fn spec_test_268_() {
         let original = r##"The number of windows in my house is
 1.  The number of doors is 6.
 "##;
@@ -7022,7 +7022,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_269() {
+    fn spec_test_269_() {
         let original = r##"- foo
 
 - bar
@@ -7058,7 +7058,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_270() {
+    fn spec_test_270_() {
         let original = r##"- foo
   - bar
     - baz
@@ -7097,7 +7097,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_271() {
+    fn spec_test_271_() {
         let original = r##"- foo
 - bar
 
@@ -7132,7 +7132,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_272() {
+    fn spec_test_272_() {
         let original = r##"-   foo
 
     notcode
@@ -7172,7 +7172,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_273() {
+    fn spec_test_273_() {
         let original = r##"- a
  - b
   - c
@@ -7211,7 +7211,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_274() {
+    fn spec_test_274_() {
         let original = r##"1. a
 
   2. b
@@ -7246,7 +7246,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_275() {
+    fn spec_test_275_() {
         let original = r##"- a
 - b
 
@@ -7280,7 +7280,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_276() {
+    fn spec_test_276_() {
         let original = r##"* a
 *
 
@@ -7312,7 +7312,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_277() {
+    fn spec_test_277_() {
         let original = r##"- a
 - b
 
@@ -7348,7 +7348,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_278() {
+    fn spec_test_278_() {
         let original = r##"- a
 - b
 
@@ -7383,7 +7383,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_279() {
+    fn spec_test_279_() {
         let original = r##"- a
 - ```
   b
@@ -7419,7 +7419,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_280() {
+    fn spec_test_280_() {
         let original = r##"- a
   - b
 
@@ -7454,7 +7454,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_281() {
+    fn spec_test_281_() {
         let original = r##"* a
   > b
   >
@@ -7485,7 +7485,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_282() {
+    fn spec_test_282_() {
         let original = r##"- a
   > b
   ```
@@ -7520,7 +7520,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_283() {
+    fn spec_test_283_() {
         let original = r##"- a
 "##;
         let expected = r##"<ul>
@@ -7543,7 +7543,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_284() {
+    fn spec_test_284_() {
         let original = r##"- a
   - b
 "##;
@@ -7571,7 +7571,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_285() {
+    fn spec_test_285_() {
         let original = r##"1. ```
    foo
    ```
@@ -7602,7 +7602,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_286() {
+    fn spec_test_286_() {
         let original = r##"* foo
   * bar
 
@@ -7634,7 +7634,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_287() {
+    fn spec_test_287_() {
         let original = r##"- a
   - b
   - c
@@ -7676,7 +7676,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_288() {
+    fn spec_test_288_() {
         let original = r##"`hi`lo`
 "##;
         let expected = r##"<p><code>hi</code>lo`</p>
@@ -7697,7 +7697,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_289() {
+    fn spec_test_289_() {
         let original = r##"\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
 "##;
         let expected = r##"<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
@@ -7718,7 +7718,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_290() {
+    fn spec_test_290_() {
         let original = r##"\	\A\a\ \3\φ\«
 "##;
         let expected = r##"<p>\	\A\a\ \3\φ\«</p>
@@ -7739,7 +7739,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_291() {
+    fn spec_test_291_() {
         let original = r##"\*not emphasized*
 \<br/> not a tag
 \[not a link](/foo)
@@ -7774,7 +7774,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_292() {
+    fn spec_test_292_() {
         let original = r##"\\*emphasis*
 "##;
         let expected = r##"<p>\<em>emphasis</em></p>
@@ -7795,7 +7795,7 @@ baz</li>
     }
 
     #[test]
-    fn spec_test_293() {
+    fn spec_test_293_() {
         let original = r##"foo\
 bar
 "##;
@@ -7818,7 +7818,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_294() {
+    fn spec_test_294_() {
         let original = r##"`` \[\` ``
 "##;
         let expected = r##"<p><code>\[\`</code></p>
@@ -7839,7 +7839,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_295() {
+    fn spec_test_295_() {
         let original = r##"    \[\]
 "##;
         let expected = r##"<pre><code>\[\]
@@ -7861,7 +7861,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_296() {
+    fn spec_test_296_() {
         let original = r##"~~~
 \[\]
 ~~~
@@ -7885,7 +7885,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_297() {
+    fn spec_test_297_() {
         let original = r##"<http://example.com?find=\*>
 "##;
         let expected = r##"<p><a href="http://example.com?find=%5C*">http://example.com?find=\*</a></p>
@@ -7906,7 +7906,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_298() {
+    fn spec_test_298_() {
         let original = r##"<a href="/bar\/)">
 "##;
         let expected = r##"<a href="/bar\/)">
@@ -7927,7 +7927,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_299() {
+    fn spec_test_299_() {
         let original = r##"[foo](/bar\* "ti\*tle")
 "##;
         let expected = r##"<p><a href="/bar*" title="ti*tle">foo</a></p>
@@ -7948,7 +7948,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_300() {
+    fn spec_test_300_() {
         let original = r##"[foo]
 
 [foo]: /bar\* "ti\*tle"
@@ -7971,7 +7971,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_301() {
+    fn spec_test_301_() {
         let original = r##"``` foo\+bar
 foo
 ```
@@ -7995,7 +7995,7 @@ foo
     }
 
     #[test]
-    fn spec_test_302() {
+    fn spec_test_302_() {
         let original = r##"&nbsp; &amp; &copy; &AElig; &Dcaron;
 &frac34; &HilbertSpace; &DifferentialD;
 &ClockwiseContourIntegral; &ngE;
@@ -8020,7 +8020,7 @@ foo
     }
 
     #[test]
-    fn spec_test_303() {
+    fn spec_test_303_() {
         let original = r##"&#35; &#1234; &#992; &#98765432; &#0;
 "##;
         let expected = r##"<p># Ӓ Ϡ � �</p>
@@ -8041,7 +8041,7 @@ foo
     }
 
     #[test]
-    fn spec_test_304() {
+    fn spec_test_304_() {
         let original = r##"&#X22; &#XD06; &#xcab;
 "##;
         let expected = r##"<p>&quot; ആ ಫ</p>
@@ -8062,7 +8062,7 @@ foo
     }
 
     #[test]
-    fn spec_test_305() {
+    fn spec_test_305_() {
         let original = r##"&nbsp &x; &#; &#x;
 &ThisIsNotDefined; &hi?;
 "##;
@@ -8085,7 +8085,7 @@ foo
     }
 
     #[test]
-    fn spec_test_306() {
+    fn spec_test_306_() {
         let original = r##"&copy
 "##;
         let expected = r##"<p>&amp;copy</p>
@@ -8106,7 +8106,7 @@ foo
     }
 
     #[test]
-    fn spec_test_307() {
+    fn spec_test_307_() {
         let original = r##"&MadeUpEntity;
 "##;
         let expected = r##"<p>&amp;MadeUpEntity;</p>
@@ -8127,7 +8127,7 @@ foo
     }
 
     #[test]
-    fn spec_test_308() {
+    fn spec_test_308_() {
         let original = r##"<a href="&ouml;&ouml;.html">
 "##;
         let expected = r##"<a href="&ouml;&ouml;.html">
@@ -8148,7 +8148,7 @@ foo
     }
 
     #[test]
-    fn spec_test_309() {
+    fn spec_test_309_() {
         let original = r##"[foo](/f&ouml;&ouml; "f&ouml;&ouml;")
 "##;
         let expected = r##"<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
@@ -8169,7 +8169,7 @@ foo
     }
 
     #[test]
-    fn spec_test_310() {
+    fn spec_test_310_() {
         let original = r##"[foo]
 
 [foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
@@ -8192,7 +8192,7 @@ foo
     }
 
     #[test]
-    fn spec_test_311() {
+    fn spec_test_311_() {
         let original = r##"``` f&ouml;&ouml;
 foo
 ```
@@ -8216,7 +8216,7 @@ foo
     }
 
     #[test]
-    fn spec_test_312() {
+    fn spec_test_312_() {
         let original = r##"`f&ouml;&ouml;`
 "##;
         let expected = r##"<p><code>f&amp;ouml;&amp;ouml;</code></p>
@@ -8237,7 +8237,7 @@ foo
     }
 
     #[test]
-    fn spec_test_313() {
+    fn spec_test_313_() {
         let original = r##"    f&ouml;f&ouml;
 "##;
         let expected = r##"<pre><code>f&amp;ouml;f&amp;ouml;
@@ -8259,7 +8259,7 @@ foo
     }
 
     #[test]
-    fn spec_test_314() {
+    fn spec_test_314_() {
         let original = r##"`foo`
 "##;
         let expected = r##"<p><code>foo</code></p>
@@ -8280,7 +8280,7 @@ foo
     }
 
     #[test]
-    fn spec_test_315() {
+    fn spec_test_315_() {
         let original = r##"`` foo ` bar  ``
 "##;
         let expected = r##"<p><code>foo ` bar</code></p>
@@ -8301,7 +8301,7 @@ foo
     }
 
     #[test]
-    fn spec_test_316() {
+    fn spec_test_316_() {
         let original = r##"` `` `
 "##;
         let expected = r##"<p><code>``</code></p>
@@ -8322,7 +8322,7 @@ foo
     }
 
     #[test]
-    fn spec_test_317() {
+    fn spec_test_317_() {
         let original = r##"``
 foo
 ``
@@ -8345,7 +8345,7 @@ foo
     }
 
     #[test]
-    fn spec_test_318() {
+    fn spec_test_318_() {
         let original = r##"`foo   bar
   baz`
 "##;
@@ -8367,7 +8367,7 @@ foo
     }
 
     #[test]
-    fn spec_test_319() {
+    fn spec_test_319_() {
         let original = r##"`a  b`
 "##;
         let expected = r##"<p><code>a  b</code></p>
@@ -8388,7 +8388,7 @@ foo
     }
 
     #[test]
-    fn spec_test_320() {
+    fn spec_test_320_() {
         let original = r##"`foo `` bar`
 "##;
         let expected = r##"<p><code>foo `` bar</code></p>
@@ -8409,7 +8409,7 @@ foo
     }
 
     #[test]
-    fn spec_test_321() {
+    fn spec_test_321_() {
         let original = r##"`foo\`bar`
 "##;
         let expected = r##"<p><code>foo\</code>bar`</p>
@@ -8430,7 +8430,7 @@ foo
     }
 
     #[test]
-    fn spec_test_322() {
+    fn spec_test_322_() {
         let original = r##"*foo`*`
 "##;
         let expected = r##"<p>*foo<code>*</code></p>
@@ -8451,7 +8451,7 @@ foo
     }
 
     #[test]
-    fn spec_test_323() {
+    fn spec_test_323_() {
         let original = r##"[not a `link](/foo`)
 "##;
         let expected = r##"<p>[not a <code>link](/foo</code>)</p>
@@ -8472,7 +8472,7 @@ foo
     }
 
     #[test]
-    fn spec_test_324() {
+    fn spec_test_324_() {
         let original = r##"`<a href="`">`
 "##;
         let expected = r##"<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>
@@ -8493,7 +8493,7 @@ foo
     }
 
     #[test]
-    fn spec_test_325() {
+    fn spec_test_325_() {
         let original = r##"<a href="`">`
 "##;
         let expected = r##"<p><a href="`">`</p>
@@ -8514,7 +8514,7 @@ foo
     }
 
     #[test]
-    fn spec_test_326() {
+    fn spec_test_326_() {
         let original = r##"`<http://foo.bar.`baz>`
 "##;
         let expected = r##"<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>
@@ -8535,7 +8535,7 @@ foo
     }
 
     #[test]
-    fn spec_test_327() {
+    fn spec_test_327_() {
         let original = r##"<http://foo.bar.`baz>`
 "##;
         let expected = r##"<p><a href="http://foo.bar.%60baz">http://foo.bar.`baz</a>`</p>
@@ -8556,7 +8556,7 @@ foo
     }
 
     #[test]
-    fn spec_test_328() {
+    fn spec_test_328_() {
         let original = r##"```foo``
 "##;
         let expected = r##"<p>```foo``</p>
@@ -8577,7 +8577,7 @@ foo
     }
 
     #[test]
-    fn spec_test_329() {
+    fn spec_test_329_() {
         let original = r##"`foo
 "##;
         let expected = r##"<p>`foo</p>
@@ -8598,7 +8598,7 @@ foo
     }
 
     #[test]
-    fn spec_test_330() {
+    fn spec_test_330_() {
         let original = r##"`foo``bar``
 "##;
         let expected = r##"<p>`foo<code>bar</code></p>
@@ -8619,7 +8619,7 @@ foo
     }
 
     #[test]
-    fn spec_test_331() {
+    fn spec_test_331_() {
         let original = r##"*foo bar*
 "##;
         let expected = r##"<p><em>foo bar</em></p>
@@ -8640,7 +8640,7 @@ foo
     }
 
     #[test]
-    fn spec_test_332() {
+    fn spec_test_332_() {
         let original = r##"a * foo bar*
 "##;
         let expected = r##"<p>a * foo bar*</p>
@@ -8661,7 +8661,7 @@ foo
     }
 
     #[test]
-    fn spec_test_333() {
+    fn spec_test_333_() {
         let original = r##"a*"foo"*
 "##;
         let expected = r##"<p>a*&quot;foo&quot;*</p>
@@ -8682,7 +8682,7 @@ foo
     }
 
     #[test]
-    fn spec_test_334() {
+    fn spec_test_334_() {
         let original = r##"* a *
 "##;
         let expected = r##"<p>* a *</p>
@@ -8703,7 +8703,7 @@ foo
     }
 
     #[test]
-    fn spec_test_335() {
+    fn spec_test_335_() {
         let original = r##"foo*bar*
 "##;
         let expected = r##"<p>foo<em>bar</em></p>
@@ -8724,7 +8724,7 @@ foo
     }
 
     #[test]
-    fn spec_test_336() {
+    fn spec_test_336_() {
         let original = r##"5*6*78
 "##;
         let expected = r##"<p>5<em>6</em>78</p>
@@ -8745,7 +8745,7 @@ foo
     }
 
     #[test]
-    fn spec_test_337() {
+    fn spec_test_337_() {
         let original = r##"_foo bar_
 "##;
         let expected = r##"<p><em>foo bar</em></p>
@@ -8766,7 +8766,7 @@ foo
     }
 
     #[test]
-    fn spec_test_338() {
+    fn spec_test_338_() {
         let original = r##"_ foo bar_
 "##;
         let expected = r##"<p>_ foo bar_</p>
@@ -8787,7 +8787,7 @@ foo
     }
 
     #[test]
-    fn spec_test_339() {
+    fn spec_test_339_() {
         let original = r##"a_"foo"_
 "##;
         let expected = r##"<p>a_&quot;foo&quot;_</p>
@@ -8808,7 +8808,7 @@ foo
     }
 
     #[test]
-    fn spec_test_340() {
+    fn spec_test_340_() {
         let original = r##"foo_bar_
 "##;
         let expected = r##"<p>foo_bar_</p>
@@ -8829,7 +8829,7 @@ foo
     }
 
     #[test]
-    fn spec_test_341() {
+    fn spec_test_341_() {
         let original = r##"5_6_78
 "##;
         let expected = r##"<p>5_6_78</p>
@@ -8850,7 +8850,7 @@ foo
     }
 
     #[test]
-    fn spec_test_342() {
+    fn spec_test_342_() {
         let original = r##"пристаням_стремятся_
 "##;
         let expected = r##"<p>пристаням_стремятся_</p>
@@ -8871,7 +8871,7 @@ foo
     }
 
     #[test]
-    fn spec_test_343() {
+    fn spec_test_343_() {
         let original = r##"aa_"bb"_cc
 "##;
         let expected = r##"<p>aa_&quot;bb&quot;_cc</p>
@@ -8892,7 +8892,7 @@ foo
     }
 
     #[test]
-    fn spec_test_344() {
+    fn spec_test_344_() {
         let original = r##"foo-_(bar)_
 "##;
         let expected = r##"<p>foo-<em>(bar)</em></p>
@@ -8913,7 +8913,7 @@ foo
     }
 
     #[test]
-    fn spec_test_345() {
+    fn spec_test_345_() {
         let original = r##"_foo*
 "##;
         let expected = r##"<p>_foo*</p>
@@ -8934,7 +8934,7 @@ foo
     }
 
     #[test]
-    fn spec_test_346() {
+    fn spec_test_346_() {
         let original = r##"*foo bar *
 "##;
         let expected = r##"<p>*foo bar *</p>
@@ -8955,7 +8955,7 @@ foo
     }
 
     #[test]
-    fn spec_test_347() {
+    fn spec_test_347_() {
         let original = r##"*foo bar
 *
 "##;
@@ -8978,7 +8978,7 @@ foo
     }
 
     #[test]
-    fn spec_test_348() {
+    fn spec_test_348_() {
         let original = r##"*(*foo)
 "##;
         let expected = r##"<p>*(*foo)</p>
@@ -8999,7 +8999,7 @@ foo
     }
 
     #[test]
-    fn spec_test_349() {
+    fn spec_test_349_() {
         let original = r##"*(*foo*)*
 "##;
         let expected = r##"<p><em>(<em>foo</em>)</em></p>
@@ -9020,7 +9020,7 @@ foo
     }
 
     #[test]
-    fn spec_test_350() {
+    fn spec_test_350_() {
         let original = r##"*foo*bar
 "##;
         let expected = r##"<p><em>foo</em>bar</p>
@@ -9041,7 +9041,7 @@ foo
     }
 
     #[test]
-    fn spec_test_351() {
+    fn spec_test_351_() {
         let original = r##"_foo bar _
 "##;
         let expected = r##"<p>_foo bar _</p>
@@ -9062,7 +9062,7 @@ foo
     }
 
     #[test]
-    fn spec_test_352() {
+    fn spec_test_352_() {
         let original = r##"_(_foo)
 "##;
         let expected = r##"<p>_(_foo)</p>
@@ -9083,7 +9083,7 @@ foo
     }
 
     #[test]
-    fn spec_test_353() {
+    fn spec_test_353_() {
         let original = r##"_(_foo_)_
 "##;
         let expected = r##"<p><em>(<em>foo</em>)</em></p>
@@ -9104,7 +9104,7 @@ foo
     }
 
     #[test]
-    fn spec_test_354() {
+    fn spec_test_354_() {
         let original = r##"_foo_bar
 "##;
         let expected = r##"<p>_foo_bar</p>
@@ -9125,7 +9125,7 @@ foo
     }
 
     #[test]
-    fn spec_test_355() {
+    fn spec_test_355_() {
         let original = r##"_пристаням_стремятся
 "##;
         let expected = r##"<p>_пристаням_стремятся</p>
@@ -9146,7 +9146,7 @@ foo
     }
 
     #[test]
-    fn spec_test_356() {
+    fn spec_test_356_() {
         let original = r##"_foo_bar_baz_
 "##;
         let expected = r##"<p><em>foo_bar_baz</em></p>
@@ -9167,7 +9167,7 @@ foo
     }
 
     #[test]
-    fn spec_test_357() {
+    fn spec_test_357_() {
         let original = r##"_(bar)_.
 "##;
         let expected = r##"<p><em>(bar)</em>.</p>
@@ -9188,7 +9188,7 @@ foo
     }
 
     #[test]
-    fn spec_test_358() {
+    fn spec_test_358_() {
         let original = r##"**foo bar**
 "##;
         let expected = r##"<p><strong>foo bar</strong></p>
@@ -9209,7 +9209,7 @@ foo
     }
 
     #[test]
-    fn spec_test_359() {
+    fn spec_test_359_() {
         let original = r##"** foo bar**
 "##;
         let expected = r##"<p>** foo bar**</p>
@@ -9230,7 +9230,7 @@ foo
     }
 
     #[test]
-    fn spec_test_360() {
+    fn spec_test_360_() {
         let original = r##"a**"foo"**
 "##;
         let expected = r##"<p>a**&quot;foo&quot;**</p>
@@ -9251,7 +9251,7 @@ foo
     }
 
     #[test]
-    fn spec_test_361() {
+    fn spec_test_361_() {
         let original = r##"foo**bar**
 "##;
         let expected = r##"<p>foo<strong>bar</strong></p>
@@ -9272,7 +9272,7 @@ foo
     }
 
     #[test]
-    fn spec_test_362() {
+    fn spec_test_362_() {
         let original = r##"__foo bar__
 "##;
         let expected = r##"<p><strong>foo bar</strong></p>
@@ -9293,7 +9293,7 @@ foo
     }
 
     #[test]
-    fn spec_test_363() {
+    fn spec_test_363_() {
         let original = r##"__ foo bar__
 "##;
         let expected = r##"<p>__ foo bar__</p>
@@ -9314,7 +9314,7 @@ foo
     }
 
     #[test]
-    fn spec_test_364() {
+    fn spec_test_364_() {
         let original = r##"__
 foo bar__
 "##;
@@ -9337,7 +9337,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_365() {
+    fn spec_test_365_() {
         let original = r##"a__"foo"__
 "##;
         let expected = r##"<p>a__&quot;foo&quot;__</p>
@@ -9358,7 +9358,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_366() {
+    fn spec_test_366_() {
         let original = r##"foo__bar__
 "##;
         let expected = r##"<p>foo__bar__</p>
@@ -9379,7 +9379,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_367() {
+    fn spec_test_367_() {
         let original = r##"5__6__78
 "##;
         let expected = r##"<p>5__6__78</p>
@@ -9400,7 +9400,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_368() {
+    fn spec_test_368_() {
         let original = r##"пристаням__стремятся__
 "##;
         let expected = r##"<p>пристаням__стремятся__</p>
@@ -9421,7 +9421,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_369() {
+    fn spec_test_369_() {
         let original = r##"__foo, __bar__, baz__
 "##;
         let expected = r##"<p><strong>foo, <strong>bar</strong>, baz</strong></p>
@@ -9442,7 +9442,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_370() {
+    fn spec_test_370_() {
         let original = r##"foo-__(bar)__
 "##;
         let expected = r##"<p>foo-<strong>(bar)</strong></p>
@@ -9463,7 +9463,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_371() {
+    fn spec_test_371_() {
         let original = r##"**foo bar **
 "##;
         let expected = r##"<p>**foo bar **</p>
@@ -9484,7 +9484,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_372() {
+    fn spec_test_372_() {
         let original = r##"**(**foo)
 "##;
         let expected = r##"<p>**(**foo)</p>
@@ -9505,7 +9505,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_373() {
+    fn spec_test_373_() {
         let original = r##"*(**foo**)*
 "##;
         let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
@@ -9526,7 +9526,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_374() {
+    fn spec_test_374_() {
         let original = r##"**Gomphocarpus (*Gomphocarpus physocarpus*, syn.
 *Asclepias physocarpa*)**
 "##;
@@ -9549,7 +9549,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_375() {
+    fn spec_test_375_() {
         let original = r##"**foo "*bar*" foo**
 "##;
         let expected = r##"<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>
@@ -9570,7 +9570,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_376() {
+    fn spec_test_376_() {
         let original = r##"**foo**bar
 "##;
         let expected = r##"<p><strong>foo</strong>bar</p>
@@ -9591,7 +9591,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_377() {
+    fn spec_test_377_() {
         let original = r##"__foo bar __
 "##;
         let expected = r##"<p>__foo bar __</p>
@@ -9612,7 +9612,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_378() {
+    fn spec_test_378_() {
         let original = r##"__(__foo)
 "##;
         let expected = r##"<p>__(__foo)</p>
@@ -9633,7 +9633,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_379() {
+    fn spec_test_379_() {
         let original = r##"_(__foo__)_
 "##;
         let expected = r##"<p><em>(<strong>foo</strong>)</em></p>
@@ -9654,7 +9654,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_380() {
+    fn spec_test_380_() {
         let original = r##"__foo__bar
 "##;
         let expected = r##"<p>__foo__bar</p>
@@ -9675,7 +9675,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_381() {
+    fn spec_test_381_() {
         let original = r##"__пристаням__стремятся
 "##;
         let expected = r##"<p>__пристаням__стремятся</p>
@@ -9696,7 +9696,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_382() {
+    fn spec_test_382_() {
         let original = r##"__foo__bar__baz__
 "##;
         let expected = r##"<p><strong>foo__bar__baz</strong></p>
@@ -9717,7 +9717,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_383() {
+    fn spec_test_383_() {
         let original = r##"__(bar)__.
 "##;
         let expected = r##"<p><strong>(bar)</strong>.</p>
@@ -9738,7 +9738,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_384() {
+    fn spec_test_384_() {
         let original = r##"*foo [bar](/url)*
 "##;
         let expected = r##"<p><em>foo <a href="/url">bar</a></em></p>
@@ -9759,7 +9759,7 @@ foo bar__</p>
     }
 
     #[test]
-    fn spec_test_385() {
+    fn spec_test_385_() {
         let original = r##"*foo
 bar*
 "##;
@@ -9782,7 +9782,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_386() {
+    fn spec_test_386_() {
         let original = r##"_foo __bar__ baz_
 "##;
         let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
@@ -9803,7 +9803,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_387() {
+    fn spec_test_387_() {
         let original = r##"_foo _bar_ baz_
 "##;
         let expected = r##"<p><em>foo <em>bar</em> baz</em></p>
@@ -9824,7 +9824,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_388() {
+    fn spec_test_388_() {
         let original = r##"__foo_ bar_
 "##;
         let expected = r##"<p><em><em>foo</em> bar</em></p>
@@ -9845,7 +9845,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_389() {
+    fn spec_test_389_() {
         let original = r##"*foo *bar**
 "##;
         let expected = r##"<p><em>foo <em>bar</em></em></p>
@@ -9866,7 +9866,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_390() {
+    fn spec_test_390_() {
         let original = r##"*foo **bar** baz*
 "##;
         let expected = r##"<p><em>foo <strong>bar</strong> baz</em></p>
@@ -9887,7 +9887,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_391() {
+    fn spec_test_391_() {
         let original = r##"*foo**bar**baz*
 "##;
         let expected = r##"<p><em>foo<strong>bar</strong>baz</em></p>
@@ -9908,7 +9908,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_392() {
+    fn spec_test_392_() {
         let original = r##"***foo** bar*
 "##;
         let expected = r##"<p><em><strong>foo</strong> bar</em></p>
@@ -9929,7 +9929,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_393() {
+    fn spec_test_393_() {
         let original = r##"*foo **bar***
 "##;
         let expected = r##"<p><em>foo <strong>bar</strong></em></p>
@@ -9950,7 +9950,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_394() {
+    fn spec_test_394_() {
         let original = r##"*foo**bar***
 "##;
         let expected = r##"<p><em>foo<strong>bar</strong></em></p>
@@ -9971,7 +9971,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_395() {
+    fn spec_test_395_() {
         let original = r##"*foo **bar *baz* bim** bop*
 "##;
         let expected = r##"<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
@@ -9992,7 +9992,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_396() {
+    fn spec_test_396_() {
         let original = r##"*foo [*bar*](/url)*
 "##;
         let expected = r##"<p><em>foo <a href="/url"><em>bar</em></a></em></p>
@@ -10013,7 +10013,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_397() {
+    fn spec_test_397_() {
         let original = r##"** is not an empty emphasis
 "##;
         let expected = r##"<p>** is not an empty emphasis</p>
@@ -10034,7 +10034,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_398() {
+    fn spec_test_398_() {
         let original = r##"**** is not an empty strong emphasis
 "##;
         let expected = r##"<p>**** is not an empty strong emphasis</p>
@@ -10055,7 +10055,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_399() {
+    fn spec_test_399_() {
         let original = r##"**foo [bar](/url)**
 "##;
         let expected = r##"<p><strong>foo <a href="/url">bar</a></strong></p>
@@ -10076,7 +10076,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_400() {
+    fn spec_test_400_() {
         let original = r##"**foo
 bar**
 "##;
@@ -10099,7 +10099,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_401() {
+    fn spec_test_401_() {
         let original = r##"__foo _bar_ baz__
 "##;
         let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
@@ -10120,7 +10120,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_402() {
+    fn spec_test_402_() {
         let original = r##"__foo __bar__ baz__
 "##;
         let expected = r##"<p><strong>foo <strong>bar</strong> baz</strong></p>
@@ -10141,7 +10141,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_403() {
+    fn spec_test_403_() {
         let original = r##"____foo__ bar__
 "##;
         let expected = r##"<p><strong><strong>foo</strong> bar</strong></p>
@@ -10162,7 +10162,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_404() {
+    fn spec_test_404_() {
         let original = r##"**foo **bar****
 "##;
         let expected = r##"<p><strong>foo <strong>bar</strong></strong></p>
@@ -10183,7 +10183,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_405() {
+    fn spec_test_405_() {
         let original = r##"**foo *bar* baz**
 "##;
         let expected = r##"<p><strong>foo <em>bar</em> baz</strong></p>
@@ -10204,7 +10204,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_406() {
+    fn spec_test_406_() {
         let original = r##"**foo*bar*baz**
 "##;
         let expected = r##"<p><strong>foo<em>bar</em>baz</strong></p>
@@ -10225,7 +10225,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_407() {
+    fn spec_test_407_() {
         let original = r##"***foo* bar**
 "##;
         let expected = r##"<p><strong><em>foo</em> bar</strong></p>
@@ -10246,7 +10246,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_408() {
+    fn spec_test_408_() {
         let original = r##"**foo *bar***
 "##;
         let expected = r##"<p><strong>foo <em>bar</em></strong></p>
@@ -10267,7 +10267,7 @@ bar</strong></p>
     }
 
     #[test]
-    fn spec_test_409() {
+    fn spec_test_409_() {
         let original = r##"**foo *bar **baz**
 bim* bop**
 "##;
@@ -10290,7 +10290,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_410() {
+    fn spec_test_410_() {
         let original = r##"**foo [*bar*](/url)**
 "##;
         let expected = r##"<p><strong>foo <a href="/url"><em>bar</em></a></strong></p>
@@ -10311,7 +10311,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_411() {
+    fn spec_test_411_() {
         let original = r##"__ is not an empty emphasis
 "##;
         let expected = r##"<p>__ is not an empty emphasis</p>
@@ -10332,7 +10332,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_412() {
+    fn spec_test_412_() {
         let original = r##"____ is not an empty strong emphasis
 "##;
         let expected = r##"<p>____ is not an empty strong emphasis</p>
@@ -10353,7 +10353,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_413() {
+    fn spec_test_413_() {
         let original = r##"foo ***
 "##;
         let expected = r##"<p>foo ***</p>
@@ -10374,7 +10374,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_414() {
+    fn spec_test_414_() {
         let original = r##"foo *\**
 "##;
         let expected = r##"<p>foo <em>*</em></p>
@@ -10395,7 +10395,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_415() {
+    fn spec_test_415_() {
         let original = r##"foo *_*
 "##;
         let expected = r##"<p>foo <em>_</em></p>
@@ -10416,7 +10416,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_416() {
+    fn spec_test_416_() {
         let original = r##"foo *****
 "##;
         let expected = r##"<p>foo *****</p>
@@ -10437,7 +10437,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_417() {
+    fn spec_test_417_() {
         let original = r##"foo **\***
 "##;
         let expected = r##"<p>foo <strong>*</strong></p>
@@ -10458,7 +10458,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_418() {
+    fn spec_test_418_() {
         let original = r##"foo **_**
 "##;
         let expected = r##"<p>foo <strong>_</strong></p>
@@ -10479,7 +10479,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_419() {
+    fn spec_test_419_() {
         let original = r##"**foo*
 "##;
         let expected = r##"<p>*<em>foo</em></p>
@@ -10500,7 +10500,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_420() {
+    fn spec_test_420_() {
         let original = r##"*foo**
 "##;
         let expected = r##"<p><em>foo</em>*</p>
@@ -10521,7 +10521,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_421() {
+    fn spec_test_421_() {
         let original = r##"***foo**
 "##;
         let expected = r##"<p>*<strong>foo</strong></p>
@@ -10542,7 +10542,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_422() {
+    fn spec_test_422_() {
         let original = r##"****foo*
 "##;
         let expected = r##"<p>***<em>foo</em></p>
@@ -10563,7 +10563,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_423() {
+    fn spec_test_423_() {
         let original = r##"**foo***
 "##;
         let expected = r##"<p><strong>foo</strong>*</p>
@@ -10584,7 +10584,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_424() {
+    fn spec_test_424_() {
         let original = r##"*foo****
 "##;
         let expected = r##"<p><em>foo</em>***</p>
@@ -10605,7 +10605,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_425() {
+    fn spec_test_425_() {
         let original = r##"foo ___
 "##;
         let expected = r##"<p>foo ___</p>
@@ -10626,7 +10626,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_426() {
+    fn spec_test_426_() {
         let original = r##"foo _\__
 "##;
         let expected = r##"<p>foo <em>_</em></p>
@@ -10647,7 +10647,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_427() {
+    fn spec_test_427_() {
         let original = r##"foo _*_
 "##;
         let expected = r##"<p>foo <em>*</em></p>
@@ -10668,7 +10668,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_428() {
+    fn spec_test_428_() {
         let original = r##"foo _____
 "##;
         let expected = r##"<p>foo _____</p>
@@ -10689,7 +10689,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_429() {
+    fn spec_test_429_() {
         let original = r##"foo __\___
 "##;
         let expected = r##"<p>foo <strong>_</strong></p>
@@ -10710,7 +10710,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_430() {
+    fn spec_test_430_() {
         let original = r##"foo __*__
 "##;
         let expected = r##"<p>foo <strong>*</strong></p>
@@ -10731,7 +10731,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_431() {
+    fn spec_test_431_() {
         let original = r##"__foo_
 "##;
         let expected = r##"<p>_<em>foo</em></p>
@@ -10752,7 +10752,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_432() {
+    fn spec_test_432_() {
         let original = r##"_foo__
 "##;
         let expected = r##"<p><em>foo</em>_</p>
@@ -10773,7 +10773,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_433() {
+    fn spec_test_433_() {
         let original = r##"___foo__
 "##;
         let expected = r##"<p>_<strong>foo</strong></p>
@@ -10794,7 +10794,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_434() {
+    fn spec_test_434_() {
         let original = r##"____foo_
 "##;
         let expected = r##"<p>___<em>foo</em></p>
@@ -10815,7 +10815,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_435() {
+    fn spec_test_435_() {
         let original = r##"__foo___
 "##;
         let expected = r##"<p><strong>foo</strong>_</p>
@@ -10836,7 +10836,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_436() {
+    fn spec_test_436_() {
         let original = r##"_foo____
 "##;
         let expected = r##"<p><em>foo</em>___</p>
@@ -10857,7 +10857,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_437() {
+    fn spec_test_437_() {
         let original = r##"**foo**
 "##;
         let expected = r##"<p><strong>foo</strong></p>
@@ -10878,7 +10878,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_438() {
+    fn spec_test_438_() {
         let original = r##"*_foo_*
 "##;
         let expected = r##"<p><em><em>foo</em></em></p>
@@ -10899,7 +10899,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_439() {
+    fn spec_test_439_() {
         let original = r##"__foo__
 "##;
         let expected = r##"<p><strong>foo</strong></p>
@@ -10920,7 +10920,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_440() {
+    fn spec_test_440_() {
         let original = r##"_*foo*_
 "##;
         let expected = r##"<p><em><em>foo</em></em></p>
@@ -10941,7 +10941,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_441() {
+    fn spec_test_441_() {
         let original = r##"****foo****
 "##;
         let expected = r##"<p><strong><strong>foo</strong></strong></p>
@@ -10962,7 +10962,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_442() {
+    fn spec_test_442_() {
         let original = r##"____foo____
 "##;
         let expected = r##"<p><strong><strong>foo</strong></strong></p>
@@ -10983,7 +10983,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_443() {
+    fn spec_test_443_() {
         let original = r##"******foo******
 "##;
         let expected = r##"<p><strong><strong><strong>foo</strong></strong></strong></p>
@@ -11004,7 +11004,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_444() {
+    fn spec_test_444_() {
         let original = r##"***foo***
 "##;
         let expected = r##"<p><em><strong>foo</strong></em></p>
@@ -11025,7 +11025,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_445() {
+    fn spec_test_445_() {
         let original = r##"_____foo_____
 "##;
         let expected = r##"<p><em><strong><strong>foo</strong></strong></em></p>
@@ -11046,7 +11046,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_446() {
+    fn spec_test_446_() {
         let original = r##"*foo _bar* baz_
 "##;
         let expected = r##"<p><em>foo _bar</em> baz_</p>
@@ -11067,7 +11067,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_447() {
+    fn spec_test_447_() {
         let original = r##"*foo __bar *baz bim__ bam*
 "##;
         let expected = r##"<p><em>foo <strong>bar *baz bim</strong> bam</em></p>
@@ -11088,7 +11088,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_448() {
+    fn spec_test_448_() {
         let original = r##"**foo **bar baz**
 "##;
         let expected = r##"<p>**foo <strong>bar baz</strong></p>
@@ -11109,7 +11109,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_449() {
+    fn spec_test_449_() {
         let original = r##"*foo *bar baz*
 "##;
         let expected = r##"<p>*foo <em>bar baz</em></p>
@@ -11130,7 +11130,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_450() {
+    fn spec_test_450_() {
         let original = r##"*[bar*](/url)
 "##;
         let expected = r##"<p>*<a href="/url">bar*</a></p>
@@ -11151,7 +11151,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_451() {
+    fn spec_test_451_() {
         let original = r##"_foo [bar_](/url)
 "##;
         let expected = r##"<p>_foo <a href="/url">bar_</a></p>
@@ -11172,7 +11172,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_452() {
+    fn spec_test_452_() {
         let original = r##"*<img src="foo" title="*"/>
 "##;
         let expected = r##"<p>*<img src="foo" title="*"/></p>
@@ -11193,7 +11193,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_453() {
+    fn spec_test_453_() {
         let original = r##"**<a href="**">
 "##;
         let expected = r##"<p>**<a href="**"></p>
@@ -11214,7 +11214,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_454() {
+    fn spec_test_454_() {
         let original = r##"__<a href="__">
 "##;
         let expected = r##"<p>__<a href="__"></p>
@@ -11235,7 +11235,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_455() {
+    fn spec_test_455_() {
         let original = r##"*a `*`*
 "##;
         let expected = r##"<p><em>a <code>*</code></em></p>
@@ -11256,7 +11256,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_456() {
+    fn spec_test_456_() {
         let original = r##"_a `_`_
 "##;
         let expected = r##"<p><em>a <code>_</code></em></p>
@@ -11277,7 +11277,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_457() {
+    fn spec_test_457_() {
         let original = r##"**a<http://foo.bar/?q=**>
 "##;
         let expected = r##"<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
@@ -11298,7 +11298,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_458() {
+    fn spec_test_458_() {
         let original = r##"__a<http://foo.bar/?q=__>
 "##;
         let expected = r##"<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
@@ -11319,7 +11319,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_459() {
+    fn spec_test_459_() {
         let original = r##"[link](/uri "title")
 "##;
         let expected = r##"<p><a href="/uri" title="title">link</a></p>
@@ -11340,7 +11340,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_460() {
+    fn spec_test_460_() {
         let original = r##"[link](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link</a></p>
@@ -11361,7 +11361,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_461() {
+    fn spec_test_461_() {
         let original = r##"[link]()
 "##;
         let expected = r##"<p><a href="">link</a></p>
@@ -11382,7 +11382,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_462() {
+    fn spec_test_462_() {
         let original = r##"[link](<>)
 "##;
         let expected = r##"<p><a href="">link</a></p>
@@ -11403,7 +11403,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_463() {
+    fn spec_test_463_() {
         let original = r##"[link](/my uri)
 "##;
         let expected = r##"<p>[link](/my uri)</p>
@@ -11424,7 +11424,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_464() {
+    fn spec_test_464_() {
         let original = r##"[link](</my uri>)
 "##;
         let expected = r##"<p>[link](&lt;/my uri&gt;)</p>
@@ -11445,7 +11445,7 @@ bim</em> bop</strong></p>
     }
 
     #[test]
-    fn spec_test_465() {
+    fn spec_test_465_() {
         let original = r##"[link](foo
 bar)
 "##;
@@ -11468,7 +11468,7 @@ bar)</p>
     }
 
     #[test]
-    fn spec_test_466() {
+    fn spec_test_466_() {
         let original = r##"[link](<foo
 bar>)
 "##;
@@ -11491,7 +11491,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_467() {
+    fn spec_test_467_() {
         let original = r##"[link](\(foo\))
 "##;
         let expected = r##"<p><a href="(foo)">link</a></p>
@@ -11512,7 +11512,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_468() {
+    fn spec_test_468_() {
         let original = r##"[link](foo(and(bar)))
 "##;
         let expected = r##"<p><a href="foo(and(bar))">link</a></p>
@@ -11533,7 +11533,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_469() {
+    fn spec_test_469_() {
         let original = r##"[link](foo\(and\(bar\))
 "##;
         let expected = r##"<p><a href="foo(and(bar)">link</a></p>
@@ -11554,7 +11554,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_470() {
+    fn spec_test_470_() {
         let original = r##"[link](<foo(and(bar)>)
 "##;
         let expected = r##"<p><a href="foo(and(bar)">link</a></p>
@@ -11575,7 +11575,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_471() {
+    fn spec_test_471_() {
         let original = r##"[link](foo\)\:)
 "##;
         let expected = r##"<p><a href="foo):">link</a></p>
@@ -11596,7 +11596,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_472() {
+    fn spec_test_472_() {
         let original = r##"[link](#fragment)
 
 [link](http://example.com#fragment)
@@ -11623,7 +11623,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_473() {
+    fn spec_test_473_() {
         let original = r##"[link](foo\bar)
 "##;
         let expected = r##"<p><a href="foo%5Cbar">link</a></p>
@@ -11644,7 +11644,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_474() {
+    fn spec_test_474_() {
         let original = r##"[link](foo%20b&auml;)
 "##;
         let expected = r##"<p><a href="foo%20b%C3%A4">link</a></p>
@@ -11665,7 +11665,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_475() {
+    fn spec_test_475_() {
         let original = r##"[link]("title")
 "##;
         let expected = r##"<p><a href="%22title%22">link</a></p>
@@ -11686,7 +11686,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_476() {
+    fn spec_test_476_() {
         let original = r##"[link](/url "title")
 [link](/url 'title')
 [link](/url (title))
@@ -11711,7 +11711,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_477() {
+    fn spec_test_477_() {
         let original = r##"[link](/url "title \"&quot;")
 "##;
         let expected = r##"<p><a href="/url" title="title &quot;&quot;">link</a></p>
@@ -11732,7 +11732,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_478() {
+    fn spec_test_478_() {
         let original = r##"[link](/url "title")
 "##;
         let expected = r##"<p><a href="/url%C2%A0%22title%22">link</a></p>
@@ -11753,7 +11753,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_479() {
+    fn spec_test_479_() {
         let original = r##"[link](/url "title "and" title")
 "##;
         let expected = r##"<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>
@@ -11774,7 +11774,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_480() {
+    fn spec_test_480_() {
         let original = r##"[link](/url 'title "and" title')
 "##;
         let expected = r##"<p><a href="/url" title="title &quot;and&quot; title">link</a></p>
@@ -11795,7 +11795,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_481() {
+    fn spec_test_481_() {
         let original = r##"[link](   /uri
   "title"  )
 "##;
@@ -11817,7 +11817,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_482() {
+    fn spec_test_482_() {
         let original = r##"[link] (/uri)
 "##;
         let expected = r##"<p>[link] (/uri)</p>
@@ -11838,7 +11838,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_483() {
+    fn spec_test_483_() {
         let original = r##"[link [foo [bar]]](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link [foo [bar]]</a></p>
@@ -11859,7 +11859,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_484() {
+    fn spec_test_484_() {
         let original = r##"[link] bar](/uri)
 "##;
         let expected = r##"<p>[link] bar](/uri)</p>
@@ -11880,7 +11880,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_485() {
+    fn spec_test_485_() {
         let original = r##"[link [bar](/uri)
 "##;
         let expected = r##"<p>[link <a href="/uri">bar</a></p>
@@ -11901,7 +11901,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_486() {
+    fn spec_test_486_() {
         let original = r##"[link \[bar](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link [bar</a></p>
@@ -11922,7 +11922,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_487() {
+    fn spec_test_487_() {
         let original = r##"[link *foo **bar** `#`*](/uri)
 "##;
         let expected = r##"<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
@@ -11943,7 +11943,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_488() {
+    fn spec_test_488_() {
         let original = r##"[![moon](moon.jpg)](/uri)
 "##;
         let expected = r##"<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
@@ -11964,7 +11964,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_489() {
+    fn spec_test_489_() {
         let original = r##"[foo [bar](/uri)](/uri)
 "##;
         let expected = r##"<p>[foo <a href="/uri">bar</a>](/uri)</p>
@@ -11985,7 +11985,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_490() {
+    fn spec_test_490_() {
         let original = r##"[foo *[bar [baz](/uri)](/uri)*](/uri)
 "##;
         let expected = r##"<p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
@@ -12006,7 +12006,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_491() {
+    fn spec_test_491_() {
         let original = r##"![[[foo](uri1)](uri2)](uri3)
 "##;
         let expected = r##"<p><img src="uri3" alt="[foo](uri2)" /></p>
@@ -12027,7 +12027,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_492() {
+    fn spec_test_492_() {
         let original = r##"*[foo*](/uri)
 "##;
         let expected = r##"<p>*<a href="/uri">foo*</a></p>
@@ -12048,7 +12048,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_493() {
+    fn spec_test_493_() {
         let original = r##"[foo *bar](baz*)
 "##;
         let expected = r##"<p><a href="baz*">foo *bar</a></p>
@@ -12069,7 +12069,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_494() {
+    fn spec_test_494_() {
         let original = r##"*foo [bar* baz]
 "##;
         let expected = r##"<p><em>foo [bar</em> baz]</p>
@@ -12090,7 +12090,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_495() {
+    fn spec_test_495_() {
         let original = r##"[foo <bar attr="](baz)">
 "##;
         let expected = r##"<p>[foo <bar attr="](baz)"></p>
@@ -12111,7 +12111,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_496() {
+    fn spec_test_496_() {
         let original = r##"[foo`](/uri)`
 "##;
         let expected = r##"<p>[foo<code>](/uri)</code></p>
@@ -12132,7 +12132,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_497() {
+    fn spec_test_497_() {
         let original = r##"[foo<http://example.com/?search=](uri)>
 "##;
         let expected = r##"<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
@@ -12153,7 +12153,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_498() {
+    fn spec_test_498_() {
         let original = r##"[foo][bar]
 
 [bar]: /url "title"
@@ -12176,7 +12176,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_499() {
+    fn spec_test_499_() {
         let original = r##"[link [foo [bar]]][ref]
 
 [ref]: /uri
@@ -12199,7 +12199,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_500() {
+    fn spec_test_500_() {
         let original = r##"[link \[bar][ref]
 
 [ref]: /uri
@@ -12222,7 +12222,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_501() {
+    fn spec_test_501_() {
         let original = r##"[link *foo **bar** `#`*][ref]
 
 [ref]: /uri
@@ -12245,7 +12245,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_502() {
+    fn spec_test_502_() {
         let original = r##"[![moon](moon.jpg)][ref]
 
 [ref]: /uri
@@ -12268,7 +12268,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_503() {
+    fn spec_test_503_() {
         let original = r##"[foo [bar](/uri)][ref]
 
 [ref]: /uri
@@ -12291,7 +12291,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_504() {
+    fn spec_test_504_() {
         let original = r##"[foo *bar [baz][ref]*][ref]
 
 [ref]: /uri
@@ -12314,7 +12314,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_505() {
+    fn spec_test_505_() {
         let original = r##"*[foo*][ref]
 
 [ref]: /uri
@@ -12337,7 +12337,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_506() {
+    fn spec_test_506_() {
         let original = r##"[foo *bar][ref]
 
 [ref]: /uri
@@ -12360,7 +12360,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_507() {
+    fn spec_test_507_() {
         let original = r##"[foo <bar attr="][ref]">
 
 [ref]: /uri
@@ -12383,7 +12383,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_508() {
+    fn spec_test_508_() {
         let original = r##"[foo`][ref]`
 
 [ref]: /uri
@@ -12406,7 +12406,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_509() {
+    fn spec_test_509_() {
         let original = r##"[foo<http://example.com/?search=][ref]>
 
 [ref]: /uri
@@ -12429,7 +12429,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_510() {
+    fn spec_test_510_() {
         let original = r##"[foo][BaR]
 
 [bar]: /url "title"
@@ -12452,7 +12452,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_511() {
+    fn spec_test_511_() {
         let original = r##"[Толпой][Толпой] is a Russian word.
 
 [ТОЛПОЙ]: /url
@@ -12475,7 +12475,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_512() {
+    fn spec_test_512_() {
         let original = r##"[Foo
   bar]: /url
 
@@ -12499,7 +12499,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_513() {
+    fn spec_test_513_() {
         let original = r##"[foo] [bar]
 
 [bar]: /url "title"
@@ -12522,7 +12522,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_514() {
+    fn spec_test_514_() {
         let original = r##"[foo]
 [bar]
 
@@ -12547,7 +12547,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_515() {
+    fn spec_test_515_() {
         let original = r##"[foo]: /url1
 
 [foo]: /url2
@@ -12572,7 +12572,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_516() {
+    fn spec_test_516_() {
         let original = r##"[bar][foo\!]
 
 [foo!]: /url
@@ -12595,7 +12595,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_517() {
+    fn spec_test_517_() {
         let original = r##"[foo][ref[]
 
 [ref[]: /uri
@@ -12619,7 +12619,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_518() {
+    fn spec_test_518_() {
         let original = r##"[foo][ref[bar]]
 
 [ref[bar]]: /uri
@@ -12643,7 +12643,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_519() {
+    fn spec_test_519_() {
         let original = r##"[[[foo]]]
 
 [[[foo]]]: /url
@@ -12667,7 +12667,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_520() {
+    fn spec_test_520_() {
         let original = r##"[foo][ref\[]
 
 [ref\[]: /uri
@@ -12690,7 +12690,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_521() {
+    fn spec_test_521_() {
         let original = r##"[bar\\]: /uri
 
 [bar\\]
@@ -12713,7 +12713,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_522() {
+    fn spec_test_522_() {
         let original = r##"[]
 
 []: /uri
@@ -12737,7 +12737,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_523() {
+    fn spec_test_523_() {
         let original = r##"[
  ]
 
@@ -12765,7 +12765,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_524() {
+    fn spec_test_524_() {
         let original = r##"[foo][]
 
 [foo]: /url "title"
@@ -12788,7 +12788,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_525() {
+    fn spec_test_525_() {
         let original = r##"[*foo* bar][]
 
 [*foo* bar]: /url "title"
@@ -12811,7 +12811,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_526() {
+    fn spec_test_526_() {
         let original = r##"[Foo][]
 
 [foo]: /url "title"
@@ -12834,7 +12834,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_527() {
+    fn spec_test_527_() {
         let original = r##"[foo] 
 []
 
@@ -12859,7 +12859,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_528() {
+    fn spec_test_528_() {
         let original = r##"[foo]
 
 [foo]: /url "title"
@@ -12882,7 +12882,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_529() {
+    fn spec_test_529_() {
         let original = r##"[*foo* bar]
 
 [*foo* bar]: /url "title"
@@ -12905,7 +12905,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_530() {
+    fn spec_test_530_() {
         let original = r##"[[*foo* bar]]
 
 [*foo* bar]: /url "title"
@@ -12928,7 +12928,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_531() {
+    fn spec_test_531_() {
         let original = r##"[[bar [foo]
 
 [foo]: /url
@@ -12951,7 +12951,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_532() {
+    fn spec_test_532_() {
         let original = r##"[Foo]
 
 [foo]: /url "title"
@@ -12974,7 +12974,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_533() {
+    fn spec_test_533_() {
         let original = r##"[foo] bar
 
 [foo]: /url
@@ -12997,7 +12997,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_534() {
+    fn spec_test_534_() {
         let original = r##"\[foo]
 
 [foo]: /url "title"
@@ -13020,7 +13020,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_535() {
+    fn spec_test_535_() {
         let original = r##"[foo*]: /url
 
 *[foo*]
@@ -13043,7 +13043,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_536() {
+    fn spec_test_536_() {
         let original = r##"[foo][bar]
 
 [foo]: /url1
@@ -13067,7 +13067,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_537() {
+    fn spec_test_537_() {
         let original = r##"[foo][]
 
 [foo]: /url1
@@ -13090,7 +13090,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_538() {
+    fn spec_test_538_() {
         let original = r##"[foo]()
 
 [foo]: /url1
@@ -13113,7 +13113,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_539() {
+    fn spec_test_539_() {
         let original = r##"[foo](not a link)
 
 [foo]: /url1
@@ -13136,7 +13136,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_540() {
+    fn spec_test_540_() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url
@@ -13159,7 +13159,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_541() {
+    fn spec_test_541_() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url1
@@ -13183,7 +13183,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_542() {
+    fn spec_test_542_() {
         let original = r##"[foo][bar][baz]
 
 [baz]: /url1
@@ -13207,7 +13207,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_543() {
+    fn spec_test_543_() {
         let original = r##"![foo](/url "title")
 "##;
         let expected = r##"<p><img src="/url" alt="foo" title="title" /></p>
@@ -13228,7 +13228,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_544() {
+    fn spec_test_544_() {
         let original = r##"![foo *bar*]
 
 [foo *bar*]: train.jpg "train & tracks"
@@ -13251,7 +13251,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_545() {
+    fn spec_test_545_() {
         let original = r##"![foo ![bar](/url)](/url2)
 "##;
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
@@ -13272,7 +13272,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_546() {
+    fn spec_test_546_() {
         let original = r##"![foo [bar](/url)](/url2)
 "##;
         let expected = r##"<p><img src="/url2" alt="foo bar" /></p>
@@ -13293,7 +13293,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_547() {
+    fn spec_test_547_() {
         let original = r##"![foo *bar*][]
 
 [foo *bar*]: train.jpg "train & tracks"
@@ -13316,7 +13316,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_548() {
+    fn spec_test_548_() {
         let original = r##"![foo *bar*][foobar]
 
 [FOOBAR]: train.jpg "train & tracks"
@@ -13339,7 +13339,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_549() {
+    fn spec_test_549_() {
         let original = r##"![foo](train.jpg)
 "##;
         let expected = r##"<p><img src="train.jpg" alt="foo" /></p>
@@ -13360,7 +13360,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_550() {
+    fn spec_test_550_() {
         let original = r##"My ![foo bar](/path/to/train.jpg  "title"   )
 "##;
         let expected = r##"<p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
@@ -13381,7 +13381,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_551() {
+    fn spec_test_551_() {
         let original = r##"![foo](<url>)
 "##;
         let expected = r##"<p><img src="url" alt="foo" /></p>
@@ -13402,7 +13402,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_552() {
+    fn spec_test_552_() {
         let original = r##"![](/url)
 "##;
         let expected = r##"<p><img src="/url" alt="" /></p>
@@ -13423,7 +13423,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_553() {
+    fn spec_test_553_() {
         let original = r##"![foo][bar]
 
 [bar]: /url
@@ -13446,7 +13446,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_554() {
+    fn spec_test_554_() {
         let original = r##"![foo][bar]
 
 [BAR]: /url
@@ -13469,7 +13469,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_555() {
+    fn spec_test_555_() {
         let original = r##"![foo][]
 
 [foo]: /url "title"
@@ -13492,7 +13492,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_556() {
+    fn spec_test_556_() {
         let original = r##"![*foo* bar][]
 
 [*foo* bar]: /url "title"
@@ -13515,7 +13515,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_557() {
+    fn spec_test_557_() {
         let original = r##"![Foo][]
 
 [foo]: /url "title"
@@ -13538,7 +13538,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_558() {
+    fn spec_test_558_() {
         let original = r##"![foo] 
 []
 
@@ -13563,7 +13563,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_559() {
+    fn spec_test_559_() {
         let original = r##"![foo]
 
 [foo]: /url "title"
@@ -13586,7 +13586,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_560() {
+    fn spec_test_560_() {
         let original = r##"![*foo* bar]
 
 [*foo* bar]: /url "title"
@@ -13609,7 +13609,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_561() {
+    fn spec_test_561_() {
         let original = r##"![[foo]]
 
 [[foo]]: /url "title"
@@ -13633,7 +13633,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_562() {
+    fn spec_test_562_() {
         let original = r##"![Foo]
 
 [foo]: /url "title"
@@ -13656,7 +13656,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_563() {
+    fn spec_test_563_() {
         let original = r##"!\[foo]
 
 [foo]: /url "title"
@@ -13679,7 +13679,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_564() {
+    fn spec_test_564_() {
         let original = r##"\![foo]
 
 [foo]: /url "title"
@@ -13702,7 +13702,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_565() {
+    fn spec_test_565_() {
         let original = r##"<http://foo.bar.baz>
 "##;
         let expected = r##"<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
@@ -13723,7 +13723,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_566() {
+    fn spec_test_566_() {
         let original = r##"<http://foo.bar.baz/test?q=hello&id=22&boolean>
 "##;
         let expected = r##"<p><a href="http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
@@ -13744,7 +13744,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_567() {
+    fn spec_test_567_() {
         let original = r##"<irc://foo.bar:2233/baz>
 "##;
         let expected = r##"<p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
@@ -13765,7 +13765,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_568() {
+    fn spec_test_568_() {
         let original = r##"<MAILTO:FOO@BAR.BAZ>
 "##;
         let expected = r##"<p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
@@ -13786,7 +13786,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_569() {
+    fn spec_test_569_() {
         let original = r##"<a+b+c:d>
 "##;
         let expected = r##"<p><a href="a+b+c:d">a+b+c:d</a></p>
@@ -13807,7 +13807,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_570() {
+    fn spec_test_570_() {
         let original = r##"<made-up-scheme://foo,bar>
 "##;
         let expected = r##"<p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
@@ -13828,7 +13828,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_571() {
+    fn spec_test_571_() {
         let original = r##"<http://../>
 "##;
         let expected = r##"<p><a href="http://../">http://../</a></p>
@@ -13849,7 +13849,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_572() {
+    fn spec_test_572_() {
         let original = r##"<localhost:5001/foo>
 "##;
         let expected = r##"<p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
@@ -13870,7 +13870,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_573() {
+    fn spec_test_573_() {
         let original = r##"<http://foo.bar/baz bim>
 "##;
         let expected = r##"<p>&lt;http://foo.bar/baz bim&gt;</p>
@@ -13891,7 +13891,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_574() {
+    fn spec_test_574_() {
         let original = r##"<http://example.com/\[\>
 "##;
         let expected = r##"<p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
@@ -13912,7 +13912,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_575() {
+    fn spec_test_575_() {
         let original = r##"<foo@bar.example.com>
 "##;
         let expected = r##"<p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
@@ -13933,7 +13933,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_576() {
+    fn spec_test_576_() {
         let original = r##"<foo+special@Bar.baz-bar0.com>
 "##;
         let expected = r##"<p><a href="mailto:foo+special@Bar.baz-bar0.com">foo+special@Bar.baz-bar0.com</a></p>
@@ -13954,7 +13954,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_577() {
+    fn spec_test_577_() {
         let original = r##"<foo\+@bar.example.com>
 "##;
         let expected = r##"<p>&lt;foo+@bar.example.com&gt;</p>
@@ -13975,7 +13975,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_578() {
+    fn spec_test_578_() {
         let original = r##"<>
 "##;
         let expected = r##"<p>&lt;&gt;</p>
@@ -13996,7 +13996,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_579() {
+    fn spec_test_579_() {
         let original = r##"< http://foo.bar >
 "##;
         let expected = r##"<p>&lt; http://foo.bar &gt;</p>
@@ -14017,7 +14017,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_580() {
+    fn spec_test_580_() {
         let original = r##"<m:abc>
 "##;
         let expected = r##"<p>&lt;m:abc&gt;</p>
@@ -14038,7 +14038,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_581() {
+    fn spec_test_581_() {
         let original = r##"<foo.bar.baz>
 "##;
         let expected = r##"<p>&lt;foo.bar.baz&gt;</p>
@@ -14059,7 +14059,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_582() {
+    fn spec_test_582_() {
         let original = r##"http://example.com
 "##;
         let expected = r##"<p>http://example.com</p>
@@ -14080,7 +14080,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_583() {
+    fn spec_test_583_() {
         let original = r##"foo@bar.example.com
 "##;
         let expected = r##"<p>foo@bar.example.com</p>
@@ -14101,7 +14101,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_584() {
+    fn spec_test_584_() {
         let original = r##"<a><bab><c2c>
 "##;
         let expected = r##"<p><a><bab><c2c></p>
@@ -14122,7 +14122,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_585() {
+    fn spec_test_585_() {
         let original = r##"<a/><b2/>
 "##;
         let expected = r##"<p><a/><b2/></p>
@@ -14143,7 +14143,7 @@ bar>)</p>
     }
 
     #[test]
-    fn spec_test_586() {
+    fn spec_test_586_() {
         let original = r##"<a  /><b2
 data="foo" >
 "##;
@@ -14166,7 +14166,7 @@ data="foo" ></p>
     }
 
     #[test]
-    fn spec_test_587() {
+    fn spec_test_587_() {
         let original = r##"<a foo="bar" bam = 'baz <em>"</em>'
 _boolean zoop:33=zoop:33 />
 "##;
@@ -14189,7 +14189,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_588() {
+    fn spec_test_588_() {
         let original = r##"Foo <responsive-image src="foo.jpg" />
 "##;
         let expected = r##"<p>Foo <responsive-image src="foo.jpg" /></p>
@@ -14210,7 +14210,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_589() {
+    fn spec_test_589_() {
         let original = r##"<33> <__>
 "##;
         let expected = r##"<p>&lt;33&gt; &lt;__&gt;</p>
@@ -14231,7 +14231,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_590() {
+    fn spec_test_590_() {
         let original = r##"<a h*#ref="hi">
 "##;
         let expected = r##"<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>
@@ -14252,7 +14252,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_591() {
+    fn spec_test_591_() {
         let original = r##"<a href="hi'> <a href=hi'>
 "##;
         let expected = r##"<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>
@@ -14273,7 +14273,7 @@ _boolean zoop:33=zoop:33 /></p>
     }
 
     #[test]
-    fn spec_test_592() {
+    fn spec_test_592_() {
         let original = r##"< a><
 foo><bar/ >
 "##;
@@ -14296,7 +14296,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_593() {
+    fn spec_test_593_() {
         let original = r##"<a href='bar'title=title>
 "##;
         let expected = r##"<p>&lt;a href='bar'title=title&gt;</p>
@@ -14317,7 +14317,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_594() {
+    fn spec_test_594_() {
         let original = r##"</a></foo >
 "##;
         let expected = r##"<p></a></foo ></p>
@@ -14338,7 +14338,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_595() {
+    fn spec_test_595_() {
         let original = r##"</a href="foo">
 "##;
         let expected = r##"<p>&lt;/a href=&quot;foo&quot;&gt;</p>
@@ -14359,7 +14359,7 @@ foo&gt;&lt;bar/ &gt;</p>
     }
 
     #[test]
-    fn spec_test_596() {
+    fn spec_test_596_() {
         let original = r##"foo <!-- this is a
 comment - with hyphen -->
 "##;
@@ -14382,7 +14382,7 @@ comment - with hyphen --></p>
     }
 
     #[test]
-    fn spec_test_597() {
+    fn spec_test_597_() {
         let original = r##"foo <!-- not a comment -- two hyphens -->
 "##;
         let expected = r##"<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
@@ -14403,7 +14403,7 @@ comment - with hyphen --></p>
     }
 
     #[test]
-    fn spec_test_598() {
+    fn spec_test_598_() {
         let original = r##"foo <!--> foo -->
 
 foo <!-- foo--->
@@ -14427,7 +14427,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_599() {
+    fn spec_test_599_() {
         let original = r##"foo <?php echo $a; ?>
 "##;
         let expected = r##"<p>foo <?php echo $a; ?></p>
@@ -14448,7 +14448,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_600() {
+    fn spec_test_600_() {
         let original = r##"foo <!ELEMENT br EMPTY>
 "##;
         let expected = r##"<p>foo <!ELEMENT br EMPTY></p>
@@ -14469,7 +14469,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_601() {
+    fn spec_test_601_() {
         let original = r##"foo <![CDATA[>&<]]>
 "##;
         let expected = r##"<p>foo <![CDATA[>&<]]></p>
@@ -14490,7 +14490,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_602() {
+    fn spec_test_602_() {
         let original = r##"foo <a href="&ouml;">
 "##;
         let expected = r##"<p>foo <a href="&ouml;"></p>
@@ -14511,7 +14511,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_603() {
+    fn spec_test_603_() {
         let original = r##"foo <a href="\*">
 "##;
         let expected = r##"<p>foo <a href="\*"></p>
@@ -14532,7 +14532,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_604() {
+    fn spec_test_604_() {
         let original = r##"<a href="\"">
 "##;
         let expected = r##"<p>&lt;a href=&quot;&quot;&quot;&gt;</p>
@@ -14553,7 +14553,7 @@ foo <!-- foo--->
     }
 
     #[test]
-    fn spec_test_605() {
+    fn spec_test_605_() {
         let original = r##"foo  
 baz
 "##;
@@ -14576,7 +14576,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_606() {
+    fn spec_test_606_() {
         let original = r##"foo\
 baz
 "##;
@@ -14599,7 +14599,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_607() {
+    fn spec_test_607_() {
         let original = r##"foo       
 baz
 "##;
@@ -14622,7 +14622,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_608() {
+    fn spec_test_608_() {
         let original = r##"foo  
      bar
 "##;
@@ -14645,7 +14645,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_609() {
+    fn spec_test_609_() {
         let original = r##"foo\
      bar
 "##;
@@ -14668,7 +14668,7 @@ bar</p>
     }
 
     #[test]
-    fn spec_test_610() {
+    fn spec_test_610_() {
         let original = r##"*foo  
 bar*
 "##;
@@ -14691,7 +14691,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_611() {
+    fn spec_test_611_() {
         let original = r##"*foo\
 bar*
 "##;
@@ -14714,7 +14714,7 @@ bar</em></p>
     }
 
     #[test]
-    fn spec_test_612() {
+    fn spec_test_612_() {
         let original = r##"`code  
 span`
 "##;
@@ -14736,7 +14736,7 @@ span`
     }
 
     #[test]
-    fn spec_test_613() {
+    fn spec_test_613_() {
         let original = r##"`code\
 span`
 "##;
@@ -14758,7 +14758,7 @@ span`
     }
 
     #[test]
-    fn spec_test_614() {
+    fn spec_test_614_() {
         let original = r##"<a href="foo  
 bar">
 "##;
@@ -14781,7 +14781,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_615() {
+    fn spec_test_615_() {
         let original = r##"<a href="foo\
 bar">
 "##;
@@ -14804,7 +14804,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_616() {
+    fn spec_test_616_() {
         let original = r##"foo\
 "##;
         let expected = r##"<p>foo\</p>
@@ -14825,7 +14825,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_617() {
+    fn spec_test_617_() {
         let original = r##"foo  
 "##;
         let expected = r##"<p>foo</p>
@@ -14846,7 +14846,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_618() {
+    fn spec_test_618_() {
         let original = r##"### foo\
 "##;
         let expected = r##"<h3>foo\</h3>
@@ -14867,7 +14867,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_619() {
+    fn spec_test_619_() {
         let original = r##"### foo  
 "##;
         let expected = r##"<h3>foo</h3>
@@ -14888,7 +14888,7 @@ bar"></p>
     }
 
     #[test]
-    fn spec_test_620() {
+    fn spec_test_620_() {
         let original = r##"foo
 baz
 "##;
@@ -14911,7 +14911,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_621() {
+    fn spec_test_621_() {
         let original = r##"foo 
  baz
 "##;
@@ -14934,7 +14934,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_622() {
+    fn spec_test_622_() {
         let original = r##"hello $.;'there
 "##;
         let expected = r##"<p>hello $.;'there</p>
@@ -14955,7 +14955,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_623() {
+    fn spec_test_623_() {
         let original = r##"Foo χρῆν
 "##;
         let expected = r##"<p>Foo χρῆν</p>
@@ -14976,7 +14976,7 @@ baz</p>
     }
 
     #[test]
-    fn spec_test_624() {
+    fn spec_test_624_() {
         let original = r##"Multiple     spaces
 "##;
         let expected = r##"<p>Multiple     spaces</p>

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -5,7 +5,7 @@ extern crate pulldown_cmark;
 
 
     #[test]
-    fn spec_test_1() {
+    fn table_test_1_() {
         let original = r##"Test header
 -----------
 "##;
@@ -27,7 +27,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_2() {
+    fn table_test_2_() {
         let original = r##"Test|Table
 ----|-----
 "##;
@@ -50,7 +50,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_3() {
+    fn table_test_3_() {
         let original = r##"Test|Table
 ----|-----
 Test row
@@ -80,7 +80,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_4() {
+    fn table_test_4_() {
         let original = r##"> Test  | Table
 > ------|------
 > Row 1 | Every
@@ -112,7 +112,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_5() {
+    fn table_test_5_() {
         let original = r##" 1. First entry
  2. Second entry
 
@@ -150,7 +150,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_6() {
+    fn table_test_6_() {
         let original = r##"|Col 1|Col 2|
 |-----|-----|
 |R1C1 |R1C2 |
@@ -177,7 +177,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_7() {
+    fn table_test_7_() {
         let original = r##"| Col 1 | Col 2 |
 |-------|-------|
 |       |       |
@@ -204,7 +204,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_8() {
+    fn table_test_8_() {
         let original = r##"| Col 1 | Col 2 |
 |-------|-------|
 |   x   |       |
@@ -231,7 +231,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_9() {
+    fn table_test_9_() {
         let original = r##"|Col 1|Col 2|
 |-----|-----|
 |✓    |✓    |
@@ -258,7 +258,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_10() {
+    fn table_test_10_() {
         let original = r##"|  Target                       | std |rustc|cargo| notes                      |
 |-------------------------------|-----|-----|-----|----------------------------|
 | `x86_64-unknown-linux-musl`   |  ✓  |     |     | 64-bit Linux with MUSL     |
@@ -295,7 +295,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_11() {
+    fn table_test_11_() {
         let original = r##"|-|-|
 |ぃ|い|
 "##;
@@ -318,7 +318,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_12() {
+    fn table_test_12_() {
         let original = r##"|ぁ|ぃ|
 |-|-|
 |ぃ|ぃ|
@@ -343,7 +343,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_13() {
+    fn table_test_13_() {
         let original = r##"|Колонка 1|Колонка 2|
 |---------|---------|
 |Ячейка 1 |Ячейка 2 |


### PR DESCRIPTION
While the main executable can also run tests, keeping the standard
`cargo test` function useful is also helpful.

* * *

Add end character to generated tests to work with substring only
matching of tests cases.

Regex test matching was removed in early 2015 in:

https://github.com/rust-lang/rust/pull/21458

You can only filter tests by substring. What if you wanted to run
`spec_test_6`? You would run `spec_test_64` too. Adding the character,
`_` to the end allows a workaround of specifying `spec_test_6_` as the
match to run if you wanted to only run `spec_test_6_`.

E.g. `cargo test spec_test_6_`

* * *

Tests are modified to generate tests with spec names in the tests

Previously, all tests were generated with `spec_test_#_` as their name,
even if they were not generated from `spec.txt`. The `tables.txt` spec
would also generate a `spec_test_#_`. This is an issue if you wanted to
test `spec_test_6_` and only wanted to run the one from `spec.txt` and
not `tables.txt`'s `spec_test_6_`. While you could build the test
executables and only run the specific test executable with the
`spec_test_#_` you want, it's kind of annoying.

This change derives the test names from the spec filename. For example,
`spec.txt` will generate `spec_test_6_` while `tables.txt` and
`footnotes.txt` will generate `tables_test_6_` and `footnotes_test_6_`
respectively. Future optional specifications that might be added will
utilize the same rule.

This allows testing of example 6 from the `footnotes.txt` spec by simply
doing:

`cargo test footnotes_test_6_`