### PR TITLE
Modify generated test names to include spec names

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,6 +54,8 @@ fn generate_tests_from_spec() {
         let mut spec_rs = File::create(&rs_test_file)
                                .expect(&format!("Could not create {:?}", rs_test_file));
 
+        let spec_name = file_path.file_stem().unwrap().to_str().unwrap();
+
         let spec = Spec::new(&raw_spec);
         let mut n_tests = 0;
 
@@ -67,7 +69,7 @@ fn generate_tests_from_spec() {
                     r###"
 
     #[test]
-    fn spec_test_{i}() {{
+    fn {}_test_{i}() {{
         let original = r##"{original}"##;
         let expected = r##"{expected}"##;
 
@@ -84,6 +86,7 @@ fn generate_tests_from_spec() {
 
         assert_eq!(expected, s);
     }}"###,
+                    spec_name,
                     i=i+1,
                     original=testcase.original,
                     expected=testcase.expected

--- a/tests/footnotes.rs
+++ b/tests/footnotes.rs
@@ -5,7 +5,7 @@ extern crate pulldown_cmark;
 
 
     #[test]
-    fn spec_test_1() {
+    fn footnotes_test_1() {
         let original = r##"Lorem ipsum.[^a]
 
 [^a]: Cool.
@@ -31,7 +31,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_2() {
+    fn footnotes_test_2() {
         let original = r##"> This is the song that never ends.\
 > Yes it goes on and on my friends.[^lambchops]
 >
@@ -61,7 +61,7 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
     }
 
     #[test]
-    fn spec_test_3() {
+    fn footnotes_test_3() {
         let original = r##"Songs that simply loop are a popular way to annoy people. [^examples]
 
 [^examples]:
@@ -94,7 +94,7 @@ Yes it goes on and on my friends.<sup class="footnote-reference"><a href="#lambc
     }
 
     #[test]
-    fn spec_test_4() {
+    fn footnotes_test_4() {
         let original = r##"[^lorem]: If heaven ever wishes to grant me a boon, it will be a total effacing of the results of a mere chance which fixed my eye on a certain stray piece of shelf-paper. It was nothing on which I would naturally have stumbled in the course of my daily round, for it was an old number of an Australian journal, the Sydney Bulletin for April 18, 1925. It had escaped even the cutting bureau which had at the time of its issuance been avidly collecting material for my uncle's research.
 
 I had largely given over my inquiries into what Professor Angell called the "Cthulhu Cult", and was visiting a learned friend in Paterson, New Jersey; the curator of a local museum and a mineralogist of note. Examining one day the reserve specimens roughly set on the storage shelves in a rear room of the museum, my eye was caught by an odd picture in one of the old papers spread beneath the stones. It was the Sydney Bulletin I have mentioned, for my friend had wide affiliations in all conceivable foreign parts; and the picture was a half-tone cut of a hideous stone image almost identical with that which Legrasse had found in the swamp.
@@ -120,7 +120,7 @@ I had largely given over my inquiries into what Professor Angell called the "Cth
     }
 
     #[test]
-    fn spec_test_5() {
+    fn footnotes_test_5() {
         let original = r##"[^ipsum]: How much wood would a woodchuck chuck.
 
 If a woodchuck could chuck wood.
@@ -150,7 +150,7 @@ If a woodchuck could chuck wood.
     }
 
     #[test]
-    fn spec_test_6() {
+    fn footnotes_test_6() {
         let original = r##"> He's also really stupid. [^why]
 >
 > [^why]: Because your mamma!
@@ -181,7 +181,7 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
     }
 
     #[test]
-    fn spec_test_7() {
+    fn footnotes_test_7() {
         let original = r##"Nested footnotes are considered poor style. [^a] [^xkcd]
 
 [^a]: This does not mean that footnotes cannot reference each other. [^b]
@@ -226,7 +226,7 @@ As such, we can guarantee that the non-childish forms of entertainment are proba
     }
 
     #[test]
-    fn spec_test_8() {
+    fn footnotes_test_8() {
         let original = r##"[^Doh] Ray Me Fa So La Te Do! [^1]
 
 [^Doh]: I know. Wrong Doe. And it won't render right.

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -5,7 +5,7 @@ extern crate pulldown_cmark;
 
 
     #[test]
-    fn spec_test_1() {
+    fn table_test_1() {
         let original = r##"Test header
 -----------
 "##;
@@ -27,7 +27,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_2() {
+    fn table_test_2() {
         let original = r##"Test|Table
 ----|-----
 "##;
@@ -50,7 +50,7 @@ extern crate pulldown_cmark;
     }
 
     #[test]
-    fn spec_test_3() {
+    fn table_test_3() {
         let original = r##"Test|Table
 ----|-----
 Test row
@@ -80,7 +80,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_4() {
+    fn table_test_4() {
         let original = r##"> Test  | Table
 > ------|------
 > Row 1 | Every
@@ -112,7 +112,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_5() {
+    fn table_test_5() {
         let original = r##" 1. First entry
  2. Second entry
 
@@ -150,7 +150,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_6() {
+    fn table_test_6() {
         let original = r##"|Col 1|Col 2|
 |-----|-----|
 |R1C1 |R1C2 |
@@ -177,7 +177,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_7() {
+    fn table_test_7() {
         let original = r##"| Col 1 | Col 2 |
 |-------|-------|
 |       |       |
@@ -204,7 +204,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_8() {
+    fn table_test_8() {
         let original = r##"| Col 1 | Col 2 |
 |-------|-------|
 |   x   |       |
@@ -231,7 +231,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_9() {
+    fn table_test_9() {
         let original = r##"|Col 1|Col 2|
 |-----|-----|
 |✓    |✓    |
@@ -258,7 +258,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_10() {
+    fn table_test_10() {
         let original = r##"|  Target                       | std |rustc|cargo| notes                      |
 |-------------------------------|-----|-----|-----|----------------------------|
 | `x86_64-unknown-linux-musl`   |  ✓  |     |     | 64-bit Linux with MUSL     |
@@ -295,7 +295,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_11() {
+    fn table_test_11() {
         let original = r##"|-|-|
 |ぃ|い|
 "##;
@@ -318,7 +318,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_12() {
+    fn table_test_12() {
         let original = r##"|ぁ|ぃ|
 |-|-|
 |ぃ|ぃ|
@@ -343,7 +343,7 @@ Test ending
     }
 
     #[test]
-    fn spec_test_13() {
+    fn table_test_13() {
         let original = r##"|Колонка 1|Колонка 2|
 |---------|---------|
 |Ячейка 1 |Ячейка 2 |


### PR DESCRIPTION
Previously, all tests were generated with `spec_test_#` as their name,
even if they were not generated from `spec.txt`. The `tables.txt` spec
would also generate a `spec_test_#`. This is an issue if you wanted to
test `spec_test_6` and only wanted to run the one from `spec.txt` and
not `tables.txt`'s `spec_test_6` from `cargo test`. While you could
build the test executables and only run the specific test executable
with the `spec_test_#` you want, it's kind of annoying. Also, having
more specific names will make the output a little more clear as well in
a whole crate `cargo test`.

This change derives the test names from the spec filename. For example,
`spec.txt` will generate `spec_test_6` while `tables.txt` and
`footnotes.txt` will generate `tables_test_6` and `footnotes_test_6`
respectively. Future optional specifications added will utilize the same
rule.

This allows testing of example 6 from the `footnotes.txt` spec by simply
doing:

`cargo test footnotes_test_6`