### PR TITLE
Consider backslash-escapes while parsing inline text

### DIFF
--- a/src/prototype.rs
+++ b/src/prototype.rs
@@ -173,6 +173,11 @@ fn parse_line(tree: &mut Tree<Item>, s: &str, mut ix: usize) -> usize {
                 tree.append_text(begin_text, ix);
                 return ix - start;
             }
+            b'\\' if ix + 1 < s.len() && is_ascii_punctuation(s.as_bytes()[ix + 1]) => {
+                tree.append_text(begin_text, ix);
+                begin_text = ix + 1;
+                ix = ix + 2;
+            }
             c @ b'*' | c @b'_' => {
                 tree.append_text(begin_text, ix);
                 let mut count = 1;


### PR DESCRIPTION
Before: test result: FAILED. 372 passed; 249 failed; 0 ignored; 0 measured; 0 filtered out

After: test result: FAILED. 386 passed; 235 failed; 0 ignored; 0 measured; 0 filtered out

n.b. This is completedly separate from the other PR.