### PR TITLE
Add some docs to some public tag variants with non-obvious fields

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -84,9 +84,14 @@ pub enum Tag<'a> {
     // block-level tags
     Paragraph,
     Rule,
+
+    /// A heading. The field indicates the level of the heading.
     Header(i32),
+
     BlockQuote,
     CodeBlock(Cow<'a, str>),
+
+    /// A list. If the list is ordered the field indicates the number of the first item.
     List(Option<usize>),  // TODO: add delim and tight for ast (not needed for html)
     Item,
     FootnoteDefinition(Cow<'a, str>),
@@ -101,7 +106,11 @@ pub enum Tag<'a> {
     Emphasis,
     Strong,
     Code,
+
+    /// A link. The first field is the destination URL, the second is a title
     Link(Cow<'a, str>, Cow<'a, str>),
+
+    /// An image. The first field is the destination URL, the second is a title
     Image(Cow<'a, str>, Cow<'a, str>),
 }
 


### PR DESCRIPTION
This is minor, but it wasn't immediately obvious to me which field would be which for `Image` and `Link`. I threw in a doc comment for `Header` as well .

This doesn't look that pretty when rendered at the moment but hopefully rustdoc improves that in the future :) 