### PR TITLE
PartialEq derives for Tag, Event, and Alignment

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -79,7 +79,7 @@ pub struct ParseInfo<'a> {
     pub links: HashMap<String, (Cow<'a, str>, Cow<'a, str>)>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Tag<'a> {
     // block-level tags
     Paragraph,
@@ -114,7 +114,7 @@ pub enum Tag<'a> {
     Image(Cow<'a, str>, Cow<'a, str>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Event<'a> {
     Start(Tag<'a>),
     End(Tag<'a>),
@@ -126,7 +126,7 @@ pub enum Event<'a> {
     HardBreak,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Alignment {
     None,
     Left,


### PR DESCRIPTION
This adds a derive for `PartialEq` so you can compare two events/tags for equality.

In `mdbook` I want to be able to skip past some arbitrary tag (e.g. `while parser.next() != Some(Event::End(some_tag)) { /* ignore */ }`) and not being able to use `==` or `!=` makes this operation quite difficult.